### PR TITLE
Removal of `.data` references, fix to item macro hotbar drop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 acks/
 acks.zip
+src/packs/*/
+!src/packs/*.db

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ This system provides mechanics and character sheet support, and features a compe
 
 ACKS, like most B/X clones, is also broadly compatible with thousands of modules and other OSR content and rulesets with a minimum of conversion necessary.
 
+## Current branch / dev help
+
+I'll try to look at pull requests as submitted. We've enabled issues, but haven't created any at the time of this writing
+
+The main branch is essentially a fork of the original ACKS module from Happy Anarchist things stand. The lr-refactoring branch has been where I've done most of the fixes. Once we have something that doesn't simply load, but provides a playable experience, I intend to merge that as an initial release and register the module at foundry for use in ACKS. 
+
+
+
 ## Current Fix Priorities / Investigating
 
 See : <https://foundryvtt.com/article/migration/>

--- a/src/module/actor/actor-sheet.js
+++ b/src/module/actor/actor-sheet.js
@@ -1,4 +1,4 @@
-import { AcksActor } from "./entity.js";
+  import { AcksActor } from "./entity.js";
 import { AcksEntityTweaks } from "../dialog/entity-tweaks.js";
 
 export class AcksActorSheet extends ActorSheet {
@@ -15,6 +15,9 @@ export class AcksActorSheet extends ActorSheet {
     data.config.ascendingAC = game.settings.get("acks", "ascendingAC");
     data.config.encumbrance = game.settings.get("acks", "encumbranceOption");
 
+    // pull the system object out of the data subobject so the Handlebars templates can see it
+    data.system = data.data.system;
+
     // Prepare owned items
     this._prepareItems(data);
 
@@ -23,7 +26,7 @@ export class AcksActorSheet extends ActorSheet {
 
   activateEditor(target, editorOptions, initialContent) {
     // remove some controls to the editor as the space is lacking
-    if (target == "data.details.description") {
+    if (target == "system.details.description") {
       editorOptions.toolbar = "styleselect bullist hr table removeFormat save";
     }
     super.activateEditor(target, editorOptions, initialContent);
@@ -52,10 +55,10 @@ export class AcksActorSheet extends ActorSheet {
     var sortedSpells = {};
     var slots = {};
     for (var i = 0; i < spells.length; i++) {
-      let lvl = spells[i].data.lvl;
+      let lvl = spells[i].lvl;
       if (!sortedSpells[lvl]) sortedSpells[lvl] = [];
       if (!slots[lvl]) slots[lvl] = 0;
-      slots[lvl] += spells[i].data.cast;
+      slots[lvl] += spells[i].cast;
       sortedSpells[lvl].push(spells[i]);
     }
     data.slots = {
@@ -75,7 +78,7 @@ export class AcksActorSheet extends ActorSheet {
     event.preventDefault();
     let li = $(event.currentTarget).parents(".item"),
       item = this.actor.items.get(li.data("item-id")),
-      description = TextEditor.enrichHTML(item.data.data.description);
+      description = TextEditor.enrichHTML(item.system.description);
     // Toggle summary
     if (li.hasClass("expanded")) {
       let summary = li.parents(".item-entry").children(".item-summary");
@@ -96,10 +99,10 @@ export class AcksActorSheet extends ActorSheet {
     const itemId = event.currentTarget.closest(".item").dataset.itemId;
     const item = this.actor.items.get(itemId);
     if (event.target.dataset.field == "cast") {
-      return item.update({ "data.cast": parseInt(event.target.value) });
+      return item.update({ "system.cast": parseInt(event.target.value) });
     } else if (event.target.dataset.field == "memorize") {
       return item.update({
-        "data.memorized": parseInt(event.target.value),
+        "system.memorized": parseInt(event.target.value),
       });
     }
   }
@@ -113,8 +116,8 @@ export class AcksActorSheet extends ActorSheet {
       const item = this.actor.items.get(itemId);
       item.update({
         _id: item.id,
-        "data.cast": 0,
-        "item.data.data.memorized": 0
+        "system.cast": 0,
+        "item.system.memorized": 0
       });
     });
   }
@@ -145,9 +148,9 @@ export class AcksActorSheet extends ActorSheet {
       const li = $(ev.currentTarget).parents(".item");
       const item = this.actor.items.get(li.data("itemId"));
       if (item.type == "weapon") {
-        if (this.actor.data.type === "monster") {
+        if (this.actor.type === "monster") {
           item.update({
-            data: { counter: { value: item.data.data.counter.value - 1 } },
+            data: { counter: { value: item.system.counter.value - 1 } },
           });
         }
           item.rollWeapon({ skipDialog: ev.ctrlKey });
@@ -168,7 +171,7 @@ export class AcksActorSheet extends ActorSheet {
       let element = event.currentTarget;
       let attack = element.parentElement.parentElement.dataset.attack;
       const rollData = {
-        actor: this.data,
+        actor: this,
         roll: {},
       };
       actorObject.targetAttack(rollData, attack, {

--- a/src/module/actor/actor-sheet.js
+++ b/src/module/actor/actor-sheet.js
@@ -74,11 +74,11 @@ export class AcksActorSheet extends ActorSheet {
     data.spells = sortedSpells;
   }
 
-  _onItemSummary(event) {
+  async _onItemSummary(event) {
     event.preventDefault();
     let li = $(event.currentTarget).parents(".item"),
       item = this.actor.items.get(li.data("item-id")),
-      description = TextEditor.enrichHTML(item.system.description);
+      description = await TextEditor.enrichHTML(item.system.description);
     // Toggle summary
     if (li.hasClass("expanded")) {
       let summary = li.parents(".item-entry").children(".item-summary");

--- a/src/module/actor/character-sheet.js
+++ b/src/module/actor/character-sheet.js
@@ -108,7 +108,9 @@ export class AcksActorSheetCharacter extends AcksActorSheet {
       }
       let newData = {};
       newData[table] = update;
-      return this.actor.updateSource({ system: newData });
+      let result = this.actor.updateSource({ system: newData });
+      this.render(true);
+      return result;
     });
   }
 
@@ -117,8 +119,10 @@ export class AcksActorSheetCharacter extends AcksActorSheet {
     let update = data[table].value.filter((el) => el != lang);
     let newData = {};
     newData[table] = { value: update };
-    return this.actor.updateSource({ system: newData });
-  }
+    let result = this.actor.updateSource({ system: newData });
+    this.render(true);
+    return result;
+}
 
   /* -------------------------------------------- */
 
@@ -126,7 +130,7 @@ export class AcksActorSheetCharacter extends AcksActorSheet {
     event.preventDefault();
     const itemId = event.currentTarget.closest(".item").dataset.itemId;
     const item = this.actor.items.get(itemId);
-    return item.updateSource({ "system.quantity.value": parseInt(event.target.value) });
+    return item.updateSource({ system: { quantity: { value: parseInt(event.target.value) } } });
   }
 
   _onShowModifiers(event) {
@@ -253,10 +257,12 @@ export class AcksActorSheetCharacter extends AcksActorSheet {
       const item = this.actor.items.get(li.data("itemId"));
       await item.updateSource({
         _id: li.data("itemId"),
-        data: {
+        system: {
           equipped: !item.system.equipped,
         },
       });
+      this.actor.prepareData();
+      this.render(true);
     });
 
     html

--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -514,7 +514,7 @@ export class AcksActor extends Actor {
       label = game.i18n.format("ACKS.roll.attacksWith", {
         name: attData.item.name,
       });
-      dmgParts.push(attData.item.damage);
+      dmgParts.push(attData.item.system.damage);
     }
 
     let ascending = game.settings.get("acks", "ascendingAC");

--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -7,7 +7,7 @@ export class AcksActor extends Actor {
 
   prepareData() {
     super.prepareData();
-    const data = this.data.data;
+    const data = this.system;
 
     // Compute modifiers from actor scores
     this.computeModifiers();
@@ -21,7 +21,7 @@ export class AcksActor extends Actor {
     // Determine Initiative
     if (game.settings.get("acks", "initiative") != "group") {
       data.initiative.value = data.initiative.mod;
-      if (this.data.type == "character") {
+      if (this.type == "character") {
         data.initiative.value += data.scores.dex.mod;
         if (data.isSlow) {
           data.initiative.value -= 1;
@@ -36,16 +36,16 @@ export class AcksActor extends Actor {
   /*  Socket Listeners and Handlers
     /* -------------------------------------------- */
   async getExperience(value, options = {}) {
-    if (this.data.type != "character") {
+    if (this.type != "character") {
       return;
     }
 
     let modified = Math.floor(
-      value + (this.data.data.details.xp.bonus * value) / 100
+      value + (this.system.details.xp.bonus * value) / 100
     );
 
     await this.update({
-      "data.details.xp.value": modified + this.data.data.details.xp.value,
+      "system.details.xp.value": modified + this.system.details.xp.value,
     });
 
     const speaker = ChatMessage.getSpeaker({ actor: this });
@@ -59,14 +59,14 @@ export class AcksActor extends Actor {
   }
 
   isNew() {
-    const data = this.data.data;
-    if (this.data.type == "character") {
+    const data = this.system;
+    if (this.type == "character") {
       let ct = 0;
       Object.values(data.scores).forEach((el) => {
         ct += el.value;
       });
       return ct == 0 ? true : false;
-    } else if (this.data.type == "monster") {
+    } else if (this.type == "monster") {
       let ct = 0;
       Object.values(data.saves).forEach((el) => {
         ct += el.value;
@@ -85,7 +85,7 @@ export class AcksActor extends Actor {
     }
 
     await this.update({
-      "data.saves": {
+      "system.saves": {
         death: {
           value: saves.d,
         },
@@ -110,7 +110,7 @@ export class AcksActor extends Actor {
   /* -------------------------------------------- */
 
   async rollHP(options = {}) {
-    let roll = new Roll(this.data.data.hp.hd);
+    let roll = new Roll(this.system.hp.hd);
     await roll.evaluate({
       async: true,
     });
@@ -128,27 +128,27 @@ export class AcksActor extends Actor {
   rollSave(save, options = {}) {
     const label = game.i18n.localize(`ACKS.saves.${save}.long`);
     const rollParts = ["1d20"];
-    if (this.data.type == "character") {
-      rollParts.push(this.data.data.save.mod);
+    if (this.type == "character") {
+      rollParts.push(this.system.save.mod);
     }
       let data = {};
 
-    if (this.data.type == "character") {
+    if (this.type == "character") {
       data = {
-        actor: this.data,
+        actor: this,
         roll: {
           type: "above",
-          target: this.data.data.saves[save].value,
-          magic: this.data.data.scores.wis.mod
+          target: this.system.saves[save].value,
+          magic: this.system.scores.wis.mod
         },
         details: game.i18n.format("ACKS.roll.details.save", { save: label }),
       };
-    } else if (this.data.type == "monster") {
+    } else if (this.type == "monster") {
         data = {
-          actor: this.data,
+          actor: this,
           roll: {
             type: "above",
-            target: this.data.data.saves[save].value,
+            target: this.system.saves[save].value,
           },
           details: game.i18n.format("ACKS.roll.details.save", { save: label }),
         };
@@ -156,7 +156,7 @@ export class AcksActor extends Actor {
       
     let skip = options.event && options.event.ctrlKey;
 
-    const rollMethod = this.data.type == "character" ? AcksDice.RollSave : AcksDice.Roll;
+    const rollMethod = this.type == "character" ? AcksDice.RollSave : AcksDice.Roll;
 
     // Roll and return
     return rollMethod({
@@ -172,27 +172,27 @@ export class AcksActor extends Actor {
 
   rollMorale(options = {}) {
     const rollParts = ["2d6"];
-    rollParts.push(this.data.data.details.morale);
+    rollParts.push(this.system.details.morale);
 
     const data = {
-      actor: this.data,
+      actor: this,
       roll: {
         type: "table",
         table: {
           1: game.i18n.format("ACKS.morale.retreat", {
-            name: this.data.name,
+            name: this.name,
           }),
           3: game.i18n.format("ACKS.morale.fightingWithdrawal", {
-            name: this.data.name,
+            name: this.name,
           }),
           6: game.i18n.format("ACKS.morale.fight", {
-            name: this.data.name,
+            name: this.name,
           }),
           9: game.i18n.format("ACKS.morale.advanceAndPursue", {
-            name: this.data.name,
+            name: this.name,
           }),
           12: game.i18n.format("ACKS.morale.fightToTheDeath", {
-            name: this.data.name,
+            name: this.name,
           }),
         },
       },
@@ -214,27 +214,27 @@ export class AcksActor extends Actor {
 
   rollLoyalty(options = {}) {
     const rollParts = ["2d6"];
-    rollParts.push(this.data.data.details.morale);
+    rollParts.push(this.system.details.morale);
 
     const data = {
-      actor: this.data,
+      actor: this,
       roll: {
         type: "table",
         table: {
           1: game.i18n.format("ACKS.loyalty.hostility", {
-            name: this.data.name,
+            name: this.name,
           }),
           3: game.i18n.format("ACKS.loyalty.resignation", {
-            name: this.data.name,
+            name: this.name,
           }),
           6: game.i18n.format("ACKS.loyalty.grudging", {
-            name: this.data.name,
+            name: this.name,
           }),
           9: game.i18n.format("ACKS.loyalty.loyal", {
-            name: this.data.name,
+            name: this.name,
           }),
           12: game.i18n.format("ACKS.loyalty.fanatic", {
-            name: this.data.name,
+            name: this.name,
           }),
         },
       },
@@ -258,24 +258,24 @@ export class AcksActor extends Actor {
     const rollParts = ["2d6"];
 
     const data = {
-      actor: this.data,
+      actor: this,
       roll: {
         type: "table",
         table: {
           2: game.i18n.format("ACKS.reaction.Hostile", {
-            name: this.data.name,
+            name: this.name,
           }),
           3: game.i18n.format("ACKS.reaction.Unfriendly", {
-            name: this.data.name,
+            name: this.name,
           }),
           6: game.i18n.format("ACKS.reaction.Neutral", {
-            name: this.data.name,
+            name: this.name,
           }),
           9: game.i18n.format("ACKS.reaction.Indifferent", {
-            name: this.data.name,
+            name: this.name,
           }),
           12: game.i18n.format("ACKS.reaction.Friendly", {
-            name: this.data.name,
+            name: this.name,
           }),
         },
       },
@@ -300,10 +300,10 @@ export class AcksActor extends Actor {
     const rollParts = ["1d20"];
 
     const data = {
-      actor: this.data,
+      actor: this,
       roll: {
         type: "check",
-        target: this.data.data.scores[score].value,
+        target: this.system.scores[score].value,
       },
 
       details: game.i18n.format("ACKS.roll.details.attribute", {
@@ -327,13 +327,13 @@ export class AcksActor extends Actor {
 
   rollHitDice(options = {}) {
     const label = game.i18n.localize(`ACKS.roll.hd`);
-    const rollParts = [this.data.data.hp.hd];
-    if (this.data.type == "character") {
-      rollParts.push(this.data.data.scores.con.mod);
+    const rollParts = [this.system.hp.hd];
+    if (this.type == "character") {
+      rollParts.push(this.system.scores.con.mod);
     }
 
     const data = {
-      actor: this.data,
+      actor: this,
       roll: {
         type: "hitdice",
       },
@@ -353,13 +353,13 @@ export class AcksActor extends Actor {
 
   rollBHR(options = {}) {
     const label = game.i18n.localize(`ACKS.roll.bhr`);
-    const rollParts = [this.data.data.hp.bhr];
-    if (this.data.type == "character") {
+    const rollParts = [this.system.hp.bhr];
+    if (this.type == "character") {
       rollParts.push();
     }
 
     const data = {
-      actor: this.data,
+      actor: this,
       roll: {
         type: "Healing",
       },
@@ -381,14 +381,14 @@ export class AcksActor extends Actor {
     const rollParts = [];
     let label = "";
     if (options.check == "wilderness") {
-      rollParts.push(this.data.data.details.appearing.w);
+      rollParts.push(this.system.details.appearing.w);
       label = "(2)";
     } else {
-      rollParts.push(this.data.data.details.appearing.d);
+      rollParts.push(this.system.details.appearing.d);
       label = "(1)";
     }
     const data = {
-      actor: this.data,
+      actor: this,
       roll: {
         type: {
           type: "appearing",
@@ -413,10 +413,10 @@ export class AcksActor extends Actor {
     const rollParts = ["1d20"];
 
     const data = {
-      actor: this.data,
+      actor: this,
       roll: {
         type: "above",
-        target: this.data.data.exploration[expl],
+        target: this.system.exploration[expl],
       },
       details: game.i18n.format("ACKS.roll.details.exploration", {
         expl: label,
@@ -438,10 +438,10 @@ export class AcksActor extends Actor {
   }
 
   rollDamage(attData, options = {}) {
-    const data = this.data.data;
+    const data = this.system;
 
     const rollData = {
-      actor: this.data,
+      actor: this,
       item: attData.item,
       roll: {
         type: "damage",
@@ -497,7 +497,7 @@ export class AcksActor extends Actor {
   }
 
   rollAttack(attData, options = {}) {
-    const data = this.data.data;
+    const data = this.system;
     let rollParts = ["1d20"];
 
     if (game.settings.get("acks", "exploding20s")) {
@@ -506,7 +506,7 @@ export class AcksActor extends Actor {
     
     const dmgParts = [];
     let label = game.i18n.format("ACKS.roll.attacks", {
-      name: this.data.name,
+      name: this.name,
     });
     if (!attData.item) {
       dmgParts.push("1d6");
@@ -514,7 +514,7 @@ export class AcksActor extends Actor {
       label = game.i18n.format("ACKS.roll.attacksWith", {
         name: attData.item.name,
       });
-      dmgParts.push(attData.item.data.damage);
+      dmgParts.push(attData.item.damage);
     }
 
     let ascending = game.settings.get("acks", "ascendingAC");
@@ -532,8 +532,8 @@ export class AcksActor extends Actor {
         data.thac0.mod.melee.toString()
       );
     }
-    if (attData.item && attData.item.data.bonus) {
-      rollParts.push(attData.item.data.bonus);
+    if (attData.item && attData.item.bonus) {
+      rollParts.push(attData.item.bonus);
     }
     let thac0 = data.thac0.value;
     if (options.type == "melee") {
@@ -548,7 +548,7 @@ export class AcksActor extends Actor {
       dmgParts.push(data.damage.mod.missile);
     }
     const rollData = {
-      actor: this.data,
+      actor: this,
       item: attData.item,
       roll: {
         type: options.type,
@@ -573,14 +573,14 @@ export class AcksActor extends Actor {
 
   async applyDamage(amount = 0, multiplier = 1) {
     amount = Math.ceil(parseInt(amount) * multiplier);
-    const hp = this.data.data.hp;
+    const hp = this.system.hp;
 
     // Remaining goes to health
     const dh = Math.clamped(hp.value - amount, -99, hp.max);
 
     // Update the Actor
     await this.update({
-      "data.hp.value": dh,
+      "system.hp.value": dh,
     });
   }
 
@@ -595,20 +595,20 @@ export class AcksActor extends Actor {
   }
 
   _isSlow() {
-    this.data.data.isSlow = false;
-    if (this.data.type != "character") {
+    this.system.isSlow = false;
+    if (this.type != "character") {
       return;
     }
-    this.data.items.forEach((item) => {
-      if (item.type == "weapon" && item.data.slow && item.data.equipped) {
-        this.data.data.isSlow = true;
+    this.items.forEach((item) => {
+      if (item.type == "weapon" && item.slow && item.equipped) {
+        this.system.isSlow = true;
         return;
       }
     });
   }
 
   computeEncumbrance() {
-    if (this.data.type !== "character") {
+    if (this.type !== "character") {
       return;
     }
 
@@ -616,33 +616,33 @@ export class AcksActor extends Actor {
 
     let totalEncumbrance = 0;
 
-    this.data.items.forEach((item) => {
+    this.items.forEach((item) => {
       if (item.type === "item") {
         if (option === "detailed") {
-          if (item.data.data.treasure) {
-            totalEncumbrance += item.data.data.weight * item.data.data.quantity.value;
+          if (item.system.treasure) {
+            totalEncumbrance += item.system.weight * item.system.quantity.value;
           } else {
             totalEncumbrance += 166.6;
           }
         } else {
-          if (item.data.data.treasure) {
-            totalEncumbrance += 1000 * item.data.data.quantity.value;
+          if (item.system.treasure) {
+            totalEncumbrance += 1000 * item.system.quantity.value;
           } else {
             totalEncumbrance += 1000;
           }
         }
       } else if (["weapon", "armor"].includes(item.type)) {
         if (option === "detailed") {
-          totalEncumbrance += item.data.data.weight;
+          totalEncumbrance += item.system.weight;
         } else {
           totalEncumbrance += 1000;
         }
       }
     });
 
-    const maxEncumbrance = this.data.data.encumbrance.max;
+    const maxEncumbrance = this.system.encumbrance.max;
 
-    this.data.data.encumbrance = {
+    this.system.encumbrance = {
       pct: Math.clamped(
         (totalEncumbrance / maxEncumbrance) * 100,
         0,
@@ -653,43 +653,43 @@ export class AcksActor extends Actor {
       value: Math.round(totalEncumbrance),
     };
 
-    if (this.data.data.config.movementAuto) {
+    if (this.system.config.movementAuto) {
       this._calculateMovement();
     }
   }
 
   _calculateMovement() {
-    if (this.data.data.encumbrance.value > this.data.data.encumbrance.max) {
-      this.data.data.movement.base = 0;
-    } else if (this.data.data.encumbrance.value > 10000) {
-      this.data.data.movement.base = 30;
-    } else if (this.data.data.encumbrance.value > 7000) {
-      this.data.data.movement.base = 60;
-    } else if (this.data.data.encumbrance.value > 5000) {
-      this.data.data.movement.base = 90;
+    if (this.system.encumbrance.value > this.system.encumbrance.max) {
+      this.system.movement.base = 0;
+    } else if (this.system.encumbrance.value > 10000) {
+      this.system.movement.base = 30;
+    } else if (this.system.encumbrance.value > 7000) {
+      this.system.movement.base = 60;
+    } else if (this.system.encumbrance.value > 5000) {
+      this.system.movement.base = 90;
     } else {
-      this.data.data.movement.base = 120;
+      this.system.movement.base = 120;
     }
   }
 
   computeTreasure() {
-    if (this.data.type != "character") {
+    if (this.type != "character") {
       return;
     }
-    const data = this.data.data;
+    const data = this.system;
     // Compute treasure
     let total = 0;
-    let treasure = this.data.items.filter(
-      (i) => i.data.type == "item" && i.data.data.treasure
+    let treasure = this.items.filter(
+      (i) => i.type == "item" && i.system.treasure
     );
     treasure.forEach((item) => {
-      total += item.data.data.quantity.value * item.data.data.cost
+      total += item.system.quantity.value * item.system.cost
     });
     data.treasure = total;
   }
 
   computeAC() {
-    if (this.data.type != "character") {
+    if (this.type != "character") {
       return;
     }
     // Compute AC
@@ -697,17 +697,17 @@ export class AcksActor extends Actor {
     let baseAac = 0;
     let AcShield = 0;
     let AacShield = 0;
-    const data = this.data.data;
+    const data = this.system;
     data.aac.naked = baseAac + data.scores.dex.mod;
     data.ac.naked = baseAc - data.scores.dex.mod;
-    const armors = this.data.items.filter((i) => i.data.type == "armor");
+    const armors = this.items.filter((i) => i.type == "armor");
     armors.forEach((a) => {
-      if (a.data.data.equipped && a.data.data.type != "shield") {
-        baseAc = a.data.data.ac;
-        baseAac = a.data.data.aac.value;
-      } else if (a.data.data.equipped && a.data.data.type == "shield") {
-        AcShield = a.data.data.ac;
-        AacShield = a.data.data.aac.value;
+      if (a.system.equipped && a.system.type != "shield") {
+        baseAc = a.system.ac;
+        baseAac = a.system.aac.value;
+      } else if (a.system.equipped && a.system.type == "shield") {
+        AcShield = a.system.ac;
+        AacShield = a.system.aac.value;
       }
     });
     data.aac.value = baseAac + data.scores.dex.mod + AacShield + data.aac.mod;
@@ -717,10 +717,10 @@ export class AcksActor extends Actor {
   }
 
   computeModifiers() {
-    if (this.data.type != "character") {
+    if (this.type != "character") {
       return;
     }
-    const data = this.data.data;
+    const data = this.system;
 
     const standard = {
       0: -3,
@@ -832,10 +832,10 @@ export class AcksActor extends Actor {
       
   }
    computeBHR() {
-   if (this.data.type != "character") {
+   if (this.type != "character") {
       return;
     }
-    const data = this.data.data;
+    const data = this.system;
 
     const bhrcalc = {
         0: "1d2",
@@ -860,7 +860,7 @@ export class AcksActor extends Actor {
     );
    };
   computeAAB() {
-    const data = this.data.data;
+    const data = this.system;
     
     data.thac0.bba = 10 - data.thac0.throw;
   }

--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -622,7 +622,7 @@ export class AcksActor extends Actor {
           if (item.system.treasure) {
             totalEncumbrance += item.system.weight * item.system.quantity.value;
           } else {
-            totalEncumbrance += 166.6;
+            totalEncumbrance += item.system.weight === 0 ? 0 : 166.6;
           }
         } else {
           if (item.system.treasure) {

--- a/src/module/actor/monster-sheet.js
+++ b/src/module/actor/monster-sheet.js
@@ -71,13 +71,16 @@ export class AcksActorSheetMonster extends AcksActorSheet {
    * Prepare data for rendering the Actor sheet
    * The prepared data object contains both the actor data as well as additional sheet options
    */
-  getData() {
+  async getData() {
     const data = super.getData();
 
     // Settings
     data.config.morale = game.settings.get("acks", "morale");
-    data.data.data.details.treasure.link = TextEditor.enrichHTML(data.data.data.details.treasure.table);
     data.isNew = this.actor.isNew();
+    [ data.system.details.treasure.link, data.richBiography ] = await Promise.all([
+      TextEditor.enrichHTML(data.system.details.treasure.table, { async: true }),
+      textEditor.enrichHTML(this.object.system.details.biography, { async: true })
+    ]); 
     return data;
   }
 
@@ -98,7 +101,7 @@ export class AcksActorSheetMonster extends AcksActorSheet {
     } else {
       link = `@RollTable[${data.id}]`;
     }
-    this.actor.update({ "data.details.treasure.table": link });
+    this.actor.update({ "system.details.treasure.table": link });
   }
 
   /* -------------------------------------------- */
@@ -140,7 +143,7 @@ export class AcksActorSheetMonster extends AcksActorSheet {
       await weapon.update({
         data: {
           counter: {
-            value: parseInt(weapon.data.data.counter.max, 10),
+            value: parseInt(weapon.system.counter.max, 10),
           },
         },
       });
@@ -153,11 +156,11 @@ export class AcksActorSheetMonster extends AcksActorSheet {
     const item = this.actor.items.get(itemId);
     if (event.target.dataset.field == "value") {
       return item.update({
-        "data.counter.value": parseInt(event.target.value),
+        "system.counter.value": parseInt(event.target.value),
       });
     } else if (event.target.dataset.field == "max") {
       return item.update({
-        "data.counter.max": parseInt(event.target.value),
+        "system.counter.max": parseInt(event.target.value),
       });
     }
   }
@@ -254,7 +257,7 @@ export class AcksActorSheetMonster extends AcksActorSheet {
     html.find(".item-pattern").click(ev => {
       const li = $(ev.currentTarget).parents(".item");
       const item = this.actor.items.get(li.data("itemId"));
-      let currentColor = item.data.data.pattern;
+      let currentColor = item.system.pattern;
       let colors = Object.keys(CONFIG.ACKS.colors);
       let index = colors.indexOf(currentColor);
       if (index + 1 == colors.length) {
@@ -263,7 +266,7 @@ export class AcksActorSheetMonster extends AcksActorSheet {
         index++;
       }
       item.update({
-        "data.pattern": colors[index]
+        "system.pattern": colors[index]
       })
     });
 

--- a/src/module/actor/monster-sheet.js
+++ b/src/module/actor/monster-sheet.js
@@ -79,7 +79,7 @@ export class AcksActorSheetMonster extends AcksActorSheet {
     data.isNew = this.actor.isNew();
     [ data.system.details.treasure.link, data.richBiography ] = await Promise.all([
       TextEditor.enrichHTML(data.system.details.treasure.table, { async: true }),
-      textEditor.enrichHTML(this.object.system.details.biography, { async: true })
+      TextEditor.enrichHTML(this.object.system.details.biography, { async: true })
     ]); 
     return data;
   }

--- a/src/module/chat.js
+++ b/src/module/chat.js
@@ -43,7 +43,7 @@ export const addChatMessageContextOptions = function(html, options) {
 export const addChatMessageButtons = function(msg, html, data) {
   // Hide blind rolls
   let blindable = html.find('.blindable');
-  if (msg.data.blind && !game.user.isGM && blindable && blindable.data('blind') === true) {
+  if (msg.blind && !game.user.isGM && blindable && blindable.data('blind') === true) {
     blindable.replaceWith("<div class='dice-roll'><div class='dice-result'><div class='dice-formula'>???</div></div></div>");
   }
   // Buttons

--- a/src/module/combat.js
+++ b/src/module/combat.js
@@ -126,15 +126,15 @@ export class AcksCombat {
       // Append spellcast and retreat
       const controls = $(ct).find(".combatant-controls .combatant-control");
       const cmbtant = game.combat.combatants.get(ct.dataset.combatantId);
-      const moveActive = cmbtant.data.flags.acks?.moveInCombat ? "active" : "";
+      const moveActive = cmbtant.flags.acks?.moveInCombat ? "active" : "";
       controls.eq(1).after(
         `<a class='combatant-control move-combat ${moveActive}'><i class='fas fa-running'></i></a>`
       );
-      const spellActive = cmbtant.data.flags.acks?.prepareSpell ? "active" : "";
+      const spellActive = cmbtant.flags.acks?.prepareSpell ? "active" : "";
       controls.eq(1).after(
         `<a class='combatant-control prepare-spell ${spellActive}'><i class='fas fa-magic'></i></a>`
       );
-      const holdActive = cmbtant.data.flags.acks?.holdTurn ? "active" : "";
+      const holdActive = cmbtant.flags.acks?.holdTurn ? "active" : "";
       controls.eq(1).after(
         `<a class='combatant-control hold-turn ${holdActive}'><i class='fas fa-pause-circle'></i></a>`
       );
@@ -162,7 +162,7 @@ export class AcksCombat {
 
       // Get group color
       const combatant = object.viewed.combatants.get(ct.dataset.combatantId);
-      let color = combatant.data.flags.acks?.group;
+      let color = combatant.flags.acks?.group;
 
       // Append colored flag
       let controls = $(ct).find(".combatant-controls");
@@ -190,7 +190,7 @@ export class AcksCombat {
           ct.initiative &&
           ct.initiative != "-789.00" &&
           ct._id != data._id &&
-          ct.data.flags.acks.group == combatant.data.flags.acks.group
+          ct.flags.acks.group == combatant.flags.acks.group
         ) {
           groupInit = ct.initiative;
           // Set init
@@ -303,7 +303,7 @@ export class AcksCombat {
 
   static async addCombatant(combatant, options, userId) {
     let color = "black";
-    switch (combatant.token.data.disposition) {
+    switch (combatant.token.disposition) {
       case -1:
         color = "red";
         break;

--- a/src/module/combat.js
+++ b/src/module/combat.js
@@ -28,7 +28,7 @@ export class AcksCombat {
       }
 
       let initiative = groups[combatant.data.flags.acks.group].initiative;
-      if (combatant.actor.data.data.isSlow) {
+      if (combatant.actor.system.isSlow) {
         initiative -= 1;
       }
 
@@ -178,7 +178,7 @@ export class AcksCombat {
     let init = game.settings.get("acks", "initiative");
     // Why do you reroll ?
 // Legacy Slowness code from OSE
-//    if (combatant.actor.data.data.isSlow) {
+//    if (combatant.actor.system.isSlow) {
 //      data.initiative = -789;
 //      return;
 //    }

--- a/src/module/dialog/character-creation.js
+++ b/src/module/dialog/character-creation.js
@@ -27,7 +27,7 @@ export class AcksCharacterCreator extends FormApplication {
    * @return {Object}
    */
   getData() {
-    let data = this.object.data;
+    let data = this.object;
     data.user = game.user;
     data.config = CONFIG.ACKS;
     data.counters = {
@@ -72,7 +72,7 @@ export class AcksCharacterCreator extends FormApplication {
       $(ev.currentTarget).closest('form').find('button[type="submit"]').removeAttr('disabled');
     }
 
-    this.object.data.stats = {
+    this.object.stats = {
       sum: sum,
       avg: Math.round(10 * sum / n) / 10,
       std: Math.round(100 * std) / 100
@@ -81,7 +81,7 @@ export class AcksCharacterCreator extends FormApplication {
 
   rollScore(score, options = {}) {
     // Increase counter
-    this.object.data.counters[score]++;
+    this.object.counters[score]++;
 
     const label = score != "gold" ? game.i18n.localize(`ACKS.scores.${score}.long`) : "Gold";
     const rollParts = ["3d6"];
@@ -97,8 +97,8 @@ export class AcksCharacterCreator extends FormApplication {
       data: data,
       skipDialog: true,
       speaker: ChatMessage.getSpeaker({ actor: this }),
-      flavor: game.i18n.format('ACKS.dialog.generateScore', { score: label, count: this.object.data.counters[score] }),
-      title: game.i18n.format('ACKS.dialog.generateScore', { score: label, count: this.object.data.counters[score] }),
+      flavor: game.i18n.format('ACKS.dialog.generateScore', { score: label, count: this.object.counters[score] }),
+      title: game.i18n.format('ACKS.dialog.generateScore', { score: label, count: this.object.counters[score] }),
     });
   }
 
@@ -116,7 +116,7 @@ export class AcksCharacterCreator extends FormApplication {
       config: CONFIG.ACKS,
       scores: scores,
       title: game.i18n.localize("ACKS.dialog.generator"),
-      stats: this.object.data.stats,
+      stats: this.object.stats,
       gold: gold
     }
     const content = await renderTemplate("/systems/acks/templates/chat/roll-creation.html", templateData)
@@ -181,7 +181,7 @@ export class AcksCharacterCreator extends FormApplication {
   async _updateObject(event, formData) {
     event.preventDefault();
     // Update the actor
-    this.object.update(formData);
+    this.object.updateSource(formData);
     // Re-draw the updated sheet
     this.object.sheet.render(true);
   }

--- a/src/module/dialog/character-modifiers.js
+++ b/src/module/dialog/character-modifiers.js
@@ -27,7 +27,7 @@ export class AcksCharacterModifiers extends FormApplication {
    * @return {Object}
    */
   getData() {
-    const data = this.object.data;
+    const data = this.object;
 
     data.user = game.user;
 

--- a/src/module/dialog/entity-tweaks.js
+++ b/src/module/dialog/entity-tweaks.js
@@ -26,9 +26,9 @@ export class AcksEntityTweaks extends FormApplication {
    * @return {Object}
    */
   getData() {
-    const data = this.object.data;
+    const data = this.object;
 
-    if (this.object.data.type === 'character') {
+    if (this.object.type === 'character') {
       data.isCharacter = true;
     }
 
@@ -55,7 +55,7 @@ export class AcksEntityTweaks extends FormApplication {
     event.preventDefault();
 
     // Update the actor.
-    this.object.update(formData);
+    this.object.updateSource(formData);
 
     // Render the updated sheet.
     this.object.sheet.render(true);

--- a/src/module/dialog/party-sheet.js
+++ b/src/module/dialog/party-sheet.js
@@ -66,7 +66,7 @@ export class AcksPartySheet extends FormApplication {
     `;
 
     let pcs = this.object.documents.filter((actor) => {
-      return actor.getFlag('acks', 'party') && actor.data.type === "character";
+      return actor.getFlag('acks', 'party') && actor.type === "character";
     });
 
     new Dialog({
@@ -80,12 +80,12 @@ export class AcksPartySheet extends FormApplication {
             let toDeal = html.find('input[name="total"]').val();
             // calculate number of shares
             let shares = 0;
-            pcs.forEach(c => {shares += c.data.data.details.xp.share});
+            pcs.forEach(c => {shares += c.system.details.xp.share});
             const value = parseFloat(toDeal) / shares;
             if (value) {
               // Give experience
               pcs.forEach((c) => {
-                c.getExperience(Math.floor(c.data.data.details.xp.share * value));
+                c.getExperience(Math.floor(c.system.details.xp.share * value));
               });
             }
           },

--- a/src/module/dice.js
+++ b/src/module/dice.js
@@ -144,10 +144,10 @@ export class AcksDice {
     result.target = data.roll.thac0;
 
     const targetAc = data.roll.target
-      ? data.roll.target.actor.data.data.ac.value
+      ? data.roll.target.actor.system.ac.value
       : 9;
     const targetAac = data.roll.target
-      ? data.roll.target.actor.data.data.aac.value
+      ? data.roll.target.actor.system.aac.value
       : 0;
     result.victim = data.roll.target ? data.roll.target.data.name : null;
 

--- a/src/module/item/entity.js
+++ b/src/module/item/entity.js
@@ -39,11 +39,11 @@ export class AcksItem extends Item {
     html.on("click", ".item-name", this._onChatCardToggleContent.bind(this));
   }
 
-  getChatData(htmlOptions) {
+  async getChatData(htmlOptions) {
     const data = duplicate(this.system);
 
     // Rich text description
-    data.description = TextEditor.enrichHTML(data.description, htmlOptions);
+    data.description = await TextEditor.enrichHTML(data.description, htmlOptions);
 
     // Item properties
     const props = [];

--- a/src/module/item/entity.js
+++ b/src/module/item/entity.js
@@ -13,7 +13,7 @@ export class AcksItem extends Item {
   prepareData() {
     // Set default image
     let img = CONST.DEFAULT_TOKEN;
-    switch (this.data.type) {
+    switch (this.type) {
       case "spell":
         img = "/systems/acks/assets/default/spell.png";
         break;
@@ -30,7 +30,7 @@ export class AcksItem extends Item {
         img = "/systems/acks/assets/default/item.png";
         break;
     }
-    if (!this.data.img) this.data.img = img;
+    if (!this.img) this.img = img;
     super.prepareData();
   }
 
@@ -40,7 +40,7 @@ export class AcksItem extends Item {
   }
 
   getChatData(htmlOptions) {
-    const data = duplicate(this.data.data);
+    const data = duplicate(this.system);
 
     // Rich text description
     data.description = TextEditor.enrichHTML(data.description, htmlOptions);
@@ -49,10 +49,10 @@ export class AcksItem extends Item {
     const props = [];
     const labels = this.labels;
 
-    if (this.data.type == "weapon") {
+    if (this.type == "weapon") {
       data.tags.forEach(t => props.push(t.value));
     }
-    if (this.data.type == "spell") {
+    if (this.type == "spell") {
       props.push(`${data.class} ${data.lvl}`, data.range, data.duration);
     }
     if (data.hasOwnProperty("equipped")) {
@@ -65,16 +65,16 @@ export class AcksItem extends Item {
   }
 
   rollWeapon(options = {}) {
-    let isNPC = this.actor.data.type != "character";
+    let isNPC = this.actor.type != "character";
     const targets = 5;
-    const data = this.data.data;
+    const data = this.system;
     let type = isNPC ? "attack" : "melee";
     const rollData =
     {
-      item: this.data,
-      actor: this.actor.data,
+      item: this,
+      actor: this.actor,
       roll: {
-        save: this.data.data.save,
+        save: this.system.save,
         target: null
       }
     };
@@ -111,7 +111,7 @@ export class AcksItem extends Item {
   }
 
   async rollFormula(options = {}) {
-    const data = this.data.data;
+    const data = this.system;
     if (!data.roll) {
       throw new Error("This Item does not have a formula to roll!");
     }
@@ -122,8 +122,8 @@ export class AcksItem extends Item {
     let type = data.rollType;
 
     const newData = {
-      actor: this.actor.data,
-      item: this.data,
+      actor: this.actor,
+      item: this,
       roll: {
         type: type,
         target: data.rollTarget,
@@ -144,9 +144,9 @@ export class AcksItem extends Item {
   }
 
   spendSpell() {
-    this.update({
+    this.updateSource({
       data: {
-        cast: this.data.data.cast + 1,
+        cast: this.system.cast + 1,
       },
     }).then(() => {
       this.show({ skipDialog: true });
@@ -163,8 +163,8 @@ export class AcksItem extends Item {
       return `<li class='tag'>${fa}${tag}</li>`;
     };
 
-    const data = this.data.data;
-    switch (this.data.type) {
+    const data = this.system;
+    switch (this.type) {
       case "weapon":
         let wTags = formatTag(data.damage, "fa-tint");
         data.tags.forEach((t) => {
@@ -201,7 +201,7 @@ export class AcksItem extends Item {
   }
 
   pushTag(values) {
-    const data = this.data.data;
+    const data = this.system;
     let update = [];
     if (data.tags) {
       update = duplicate(data.tags);
@@ -238,16 +238,16 @@ export class AcksItem extends Item {
       update = values;
     }
     newData.tags = update;
-    return this.update({ data: newData });
+    return this.updateSource({ data: newData });
   }
 
   popTag(value) {
-    const data = this.data.data;
+    const data = this.system;
     let update = data.tags.filter((el) => el.value != value);
     let newData = {
       tags: update,
     };
-    return this.update({ data: newData });
+    return this.updateSource({ data: newData });
   }
 
   roll() {
@@ -259,7 +259,7 @@ export class AcksItem extends Item {
         this.spendSpell();
         break;
       case "ability":
-        if (this.data.data.roll) {
+        if (this.system.roll) {
           this.rollFormula();
         } else {
           this.show();
@@ -281,12 +281,12 @@ export class AcksItem extends Item {
     const templateData = {
       actor: this.actor,
       tokenId: token ? `${token.parent.id}.${token.id}` : null,
-      item: this.data,
+      item: this,
       data: this.getChatData(),
       labels: this.labels,
       isHealing: this.isHealing,
       hasDamage: this.hasDamage,
-      isSpell: this.data.type === "spell",
+      isSpell: this.type === "spell",
       hasSave: this.hasSave,
       config: CONFIG.ACKS,
     };

--- a/src/module/item/item-sheet.js
+++ b/src/module/item/item-sheet.js
@@ -36,16 +36,18 @@ export class AcksItemSheet extends ItemSheet {
   /** @override */
   get template() {
     const path = "systems/acks/templates/items/";
-    return `${path}/${this.item.data.type}-sheet.html`;
+    return `${path}/${this.item.type}-sheet.html`;
   }
 
   /**
    * Prepare data for rendering the Item sheet
    * The prepared data object contains both the actor data as well as additional sheet options
    */
-  getData() {
+  async getData() {
     const data = super.getData();
+    data.system = data.data.system;
     data.config = CONFIG.ACKS;
+    data.richDescription = await TextEditor.enrichHTML(data.system.description, { async: true });
     return data;
   }
 
@@ -68,11 +70,11 @@ export class AcksItemSheet extends ItemSheet {
       this.object.popTag(value);
     });
     html.find('a.melee-toggle').click(() => {
-      this.object.update({data: {melee: !this.object.data.data.melee}});
+      this.object.updateSource({data: {melee: !this.object.system.melee}});
     });
 
     html.find('a.missile-toggle').click(() => {
-      this.object.update({data: {missile: !this.object.data.data.missile}});
+      this.object.updateSource({data: {missile: !this.object.system.missile}});
     });
 
     super.activateListeners(html);

--- a/src/module/treasure.js
+++ b/src/module/treasure.js
@@ -41,7 +41,7 @@ async function drawTreasure(table, data) {
         const text = result.getChatText();
         data.treasure[result.id] = ({
           img: result.img,
-          text: TextEditor.enrichHTML(text),
+          text: await TextEditor.enrichHTML(text),
         });
 
         if ((result.data.type === CONST.TABLE_RESULT_TYPES.DOCUMENT)
@@ -53,8 +53,8 @@ async function drawTreasure(table, data) {
     }
   } else {
     const results = await table.roll().results;
-    results.forEach((result) => {
-      const text = TextEditor.enrichHTML(result.getChatText());
+    results.forEach(async (result) => {
+      const text = await TextEditor.enrichHTML(result.getChatText());
       data.treasure[result.id] = {img: result.img, text: text};
     });
   }

--- a/src/templates/actors/character-sheet.html
+++ b/src/templates/actors/character-sheet.html
@@ -12,7 +12,7 @@
     <a class="item" data-tab="abilities">
       {{localize "ACKS.category.abilities"}}
     </a>
-    {{#if data.data.spells.enabled}}
+    {{#if system.spells.enabled}}
     <a class="item" data-tab="spells">
       {{localize "ACKS.category.spells"}}
     </a>
@@ -33,7 +33,7 @@
     <div class="tab" data-group="primary" data-tab="abilities">
       {{> "systems/acks/templates/actors/partials/character-abilities-tab.html"}}
     </div>
-    {{#if data.data.spells.enabled}}
+    {{#if system.spells.enabled}}
     <div class="tab" data-group="primary" data-tab="spells">
       {{> "systems/acks/templates/actors/partials/character-spells-tab.html"}}
     </div>

--- a/src/templates/actors/dialogs/character-creation.html
+++ b/src/templates/actors/dialogs/character-creation.html
@@ -5,7 +5,7 @@
             <div data-score="{{id}}" class="form-group">
                 <label><a class="score-roll"><i class="fas fa-dice"></i></a> {{score}}</label>
                 <div class="form-fields">
-                    <input class="score-value" name="data.scores.{{id}}.value" type="text" value="0" data-dtype="Number"/>
+                    <input class="score-value" name="system.scores.{{id}}.value" type="text" value="0" data-dtype="Number"/>
                 </div>
             </div>
             {{/each}}

--- a/src/templates/actors/dialogs/modifiers-dialog.html
+++ b/src/templates/actors/dialogs/modifiers-dialog.html
@@ -3,10 +3,10 @@
     <label>{{localize 'ACKS.scores.str.long'}}</label>
     <ol>
       <li>
-        {{localize 'ACKS.Melee'}} ({{mod data.scores.str.mod}})
+        {{localize 'ACKS.Melee'}} ({{mod system.scores.str.mod}})
       </li>
       <li>
-        {{localize 'ACKS.exploration.od.long'}} ({{data.exploration.odMod}}+)
+        {{localize 'ACKS.exploration.od.long'}} ({{system.exploration.odMod}}+)
       </li>
     </ol>
   </div>
@@ -14,10 +14,10 @@
     <label>{{localize 'ACKS.scores.int.long'}}</label>
     <ol>
       <li>
-        {{localize 'ACKS.SpokenLanguages'}} ({{localize data.languages.spoken}})
+        {{localize 'ACKS.SpokenLanguages'}} ({{localize system.languages.spoken}})
       </li>
       <li>
-        {{localize 'ACKS.Literacy'}} ({{localize data.languages.literacy}})
+        {{localize 'ACKS.Literacy'}} ({{localize system.languages.literacy}})
       </li>
     </ol>
   </div>
@@ -25,7 +25,7 @@
     <label>{{localize 'ACKS.scores.wis.long'}}</label>
     <ol>
       <li>
-        {{localize 'ACKS.saves.magic.long'}} ({{mod data.scores.wis.mod}})
+        {{localize 'ACKS.saves.magic.long'}} ({{mod system.scores.wis.mod}})
       </li>
     </ol>
   </div>
@@ -33,13 +33,13 @@
     <label>{{localize 'ACKS.scores.dex.long'}}</label>
     <ol>
       <li>
-        {{localize 'ACKS.Missile'}} ({{mod data.scores.dex.mod}})
+        {{localize 'ACKS.Missile'}} ({{mod system.scores.dex.mod}})
       </li>
       <li>
-        {{localize 'ACKS.Initiative'}} ({{mod data.scores.dex.init}})
+        {{localize 'ACKS.Initiative'}} ({{mod system.scores.dex.init}})
       </li>
       <li>
-        {{localize 'ACKS.ArmorClass'}} ({{mod data.scores.dex.mod}})
+        {{localize 'ACKS.ArmorClass'}} ({{mod system.scores.dex.mod}})
       </li>
     </ol>
   </div>
@@ -47,7 +47,7 @@
     <label>{{localize 'ACKS.scores.con.long'}}</label>
     <ol>
       <li>
-        {{localize 'ACKS.Health'}} ({{mod data.scores.con.mod}})
+        {{localize 'ACKS.Health'}} ({{mod system.scores.con.mod}})
       </li>
     </ol>
   </div>
@@ -55,13 +55,13 @@
     <label>{{localize 'ACKS.scores.cha.long'}}</label>
     <ol>
       <li>
-        {{localize 'ACKS.NPCReaction'}} ({{mod data.scores.cha.npc}})
+        {{localize 'ACKS.NPCReaction'}} ({{mod system.scores.cha.npc}})
       </li>
       <li>
-        {{localize 'ACKS.RetainersMax'}} ({{add data.scores.cha.mod 4}})
+        {{localize 'ACKS.RetainersMax'}} ({{add system.scores.cha.mod 4}})
       </li>
       <li>
-        {{localize 'ACKS.Loyalty'}} ({{add data.scores.cha.mod 0}})
+        {{localize 'ACKS.Loyalty'}} ({{add system.scores.cha.mod 0}})
       </li>
     </ol>
   </div>

--- a/src/templates/actors/dialogs/tweaks-dialog.html
+++ b/src/templates/actors/dialogs/tweaks-dialog.html
@@ -2,21 +2,21 @@
   <div class="form-group">
     <label for="spellcaster">{{localize "ACKS.Spellcaster"}}</label>
     <div class="form-fields">
-      <input type="checkbox" name="data.spells.enabled" id="spellcaster" {{checked
-          data.spells.enabled}} data-dtype="Boolean" />
+      <input type="checkbox" name="system.spells.enabled" id="spellcaster" {{checked
+          system.spells.enabled}} data-dtype="Boolean" />
     </div>
   </div>
   <div class="form-group">
     <label for="retainer">{{localize "ACKS.Retainer"}}</label>
     <div class="form-fields">
-      <input type="checkbox" name="data.retainer.enabled" id="retainer" {{checked
-          data.retainer.enabled}}  data-dtype="Boolean"/>
+      <input type="checkbox" name="system.retainer.enabled" id="retainer" {{checked
+          system.retainer.enabled}}  data-dtype="Boolean"/>
     </div>
   </div>
   <div class="form-group">
     <label>{{localize "ACKS.InitiativeBonus"}}</label>
     <div class="form-fields">
-      <input type="text" name="data.initiative.mod" id="initiative" value="{{data.initiative.mod}}"
+      <input type="text" name="system.initiative.mod" id="initiative" value="{{system.initiative.mod}}"
         data-dtype="Number" />
     </div>
   </div>
@@ -24,54 +24,54 @@
   <div class="form-group">
     <label>{{localize "ACKS.details.experience.next"}}</label>
     <div class="form-fields">
-      <input type="text" name="data.details.xp.next" id="experiencenext" value="{{data.details.xp.next}}" data-dtype="Number" />
+      <input type="text" name="system.details.xp.next" id="experiencenext" value="{{system.details.xp.next}}" data-dtype="Number" />
     </div>
   </div>
   <div class="form-group">
     <label>{{localize "ACKS.details.experience.bonus"}} (%)</label>
     <div class="form-fields">
-      <input type="text" name="data.details.xp.bonus" id="experience" value="{{data.details.xp.bonus}}" data-dtype="Number"/>
+      <input type="text" name="system.m.details.xp.bonus" id="experience" value="{{system.details.xp.bonus}}" data-dtype="Number"/>
     </div>
   </div>
   <div class="form-group">
     <label>{{localize "ACKS.details.experience.share"}} (%)</label>
     <div class="form-fields">
-      <input type="text" name="data.details.xp.share" id="experience-share" value="{{data.details.xp.share}}" data-dtype="Number"/>
+      <input type="text" name="system.details.xp.share" id="experience-share" value="{{system.details.xp.share}}" data-dtype="Number"/>
     </div>
   </div>
   <div class="form-group">
     <label>{{localize "ACKS.MeleeBonus"}}</label>
     <div class="form-fields">
-      <input type="text" name="data.thac0.mod.melee" id="melee" value="{{data.thac0.mod.melee}}" data-dtype="Number" />
+      <input type="text" name="system.thac0.mod.melee" id="melee" value="{{system.thac0.mod.melee}}" data-dtype="Number" />
     </div>
   </div>
   <div class="form-group">
     <label>{{localize "ACKS.MeleeDamageBonus"}}</label>
     <div class="form-fields">
-      <input type="text" name="data.damage.mod.melee" id="meleedmg" value="{{data.damage.mod.melee}}" data-dtype="Number" />
+      <input type="text" name="system.damage.mod.melee" id="meleedmg" value="{{system.damage.mod.melee}}" data-dtype="Number" />
     </div>
   </div>
   <div class="form-group">
     <label>{{localize "ACKS.MissileBonus"}}</label>
     <div class="form-fields">
-      <input type="text" name="data.thac0.mod.missile" id="missile" value="{{data.thac0.mod.missile}}"
+      <input type="text" name="system.thac0.mod.missile" id="missile" value="{{system.thac0.mod.missile}}"
         data-dtype="Number" />
     </div>
   </div>
   <div class="form-group">
     <label>{{localize "ACKS.MissileDamageBonus"}}</label>
     <div class="form-fields">
-      <input type="text" name="data.damage.mod.missile" id="missiledmg" value="{{data.damage.mod.missile}}" data-dtype="Number" />
+      <input type="text" name="system.damage.mod.missile" id="missiledmg" value="{{system.damage.mod.missile}}" data-dtype="Number" />
     </div>
   </div>
   <div class="form-group">
     <label>{{localize "ACKS.ArmorClassBonus"}}</label>
     <div class="form-fields">
       {{#if config.ascendingAC}}
-      <input type="text" name="data.aac.mod" id="aac" value="{{data.aac.mod}}"
+      <input type="text" name="system.aac.mod" id="aac" value="{{system.aac.mod}}"
         data-dtype="Number" />
       {{else}}
-      <input type="text" name="data.ac.mod" id="ac" value="{{data.ac.mod}}"
+      <input type="text" name="system.ac.mod" id="ac" value="{{system.ac.mod}}"
         data-dtype="Number" />
         {{/if}}
     </div>
@@ -79,22 +79,22 @@
   <div class="form-group">
     <label>{{localize "ACKS.SaveBonus"}}</label>
     <div class="form-fields">
-      <input type="text" name="data.save.mod" id="save" value="{{data.save.mod}}"
+      <input type="text" name="system.save.mod" id="save" value="{{system.save.mod}}"
         data-dtype="Number" />
     </div>
   </div>
   <div class="form-group">
     <label>{{localize "ACKS.Encumbrance"}}</label>
     <div class="form-fields">
-      <input type="text" name="data.encumbrance.max" id="encumbrance" value="{{data.encumbrance.max}}"
+      <input type="text" name="system.encumbrance.max" id="encumbrance" value="{{system.encumbrance.max}}"
         data-dtype="Number" {{#unless user.isGM}}disabled{{/unless}} />
     </div>
   </div>
   <div class="form-group">
     <label for="movementAuto">{{localize "ACKS.Setting.MovementAuto"}}</label>
     <div class="form-fields">
-      <input type="checkbox" name="data.config.movementAuto" id="movementAuto" {{checked
-          data.config.movementAuto}}  data-dtype="Boolean" {{#unless user.isGM}}disabled{{/unless}} />
+      <input type="checkbox" name="system.config.movementAuto" id="movementAuto" {{checked
+          system.config.movementAuto}}  data-dtype="Boolean" {{#unless user.isGM}}disabled{{/unless}} />
     </div>
   </div>
   {{/if}}

--- a/src/templates/actors/monster-sheet.html
+++ b/src/templates/actors/monster-sheet.html
@@ -9,7 +9,7 @@
     <a class="item" data-tab="attributes">
       {{localize "ACKS.category.attributes"}}
     </a>
-    {{#if data.data.spells.enabled}}
+    {{#if system.spells.enabled}}
     <a class="item" data-tab="spells">
       {{localize "ACKS.category.spells"}}
     </a>
@@ -24,7 +24,7 @@
     <div class="tab" data-group="primary" data-tab="attributes">
       {{> "systems/acks/templates/actors/partials/monster-attributes-tab.html"}}
     </div>
-    {{#if data.data.spells.enabled}}
+    {{#if system.spells.enabled}}
     <div class="tab" data-group="primary" data-tab="spells">
       {{> "systems/acks/templates/actors/partials/character-spells-tab.html"}}
     </div>
@@ -33,8 +33,8 @@
       <div class="inventory">
         <div class="item-titles">{{localize "ACKS.category.notes"}}</div>
         <div class="resizable-editor" data-editor-size="320">
-          {{editor content=data.data.details.biography target="data.details.biography"
-          button=true owner=owner editable=editable}}
+          {{editor richBiography target="system.details.biography"
+          button=true editable=editable}}
         </div>
       </div>
     </div>

--- a/src/templates/actors/partials/character-abilities-tab.html
+++ b/src/templates/actors/partials/character-abilities-tab.html
@@ -2,28 +2,28 @@
   <li class="attribute flexrow" data-exploration="ld">
     <h4 class="attribute-name box-title" title="({{localize 'ACKS.exploration.ld.abrev'}}) {{localize 'ACKS.exploration.ld.long'}}"><a>{{ localize "ACKS.exploration.ld.short" }}</a></h4>
     <div class="attribute-value">
-      <input name="data.exploration.ld" type="text" value="{{data.data.exploration.ld}}" value="18"  data-dtype="Number" placeholder="0" />
+      <input name="system.exploration.ld" type="text" value="{{system.exploration.ld}}" value="18"  data-dtype="Number" placeholder="0" />
     </div>
   </li>
   <li class="attribute flexrow" data-exploration="od">
     <h4 class="attribute-name box-title" title="({{localize 'ACKS.exploration.od.abrev'}}) {{localize 'ACKS.exploration.od.long'}}"><a>{{ localize "ACKS.exploration.od.short" }}</a>
     </h4>
     <div class="attribute-value">
-      <input name="data.exploration.od" type="text" value="{{data.data.exploration.od}}" value="18"  placeholder="0" data-dtype="String" />
+      <input name="system.exploration.od" type="text" value="{{system.exploration.od}}" value="18"  placeholder="0" data-dtype="String" />
     </div>
   </li>
   <li class="attribute flexrow" data-exploration="sd">
     <h4 class="attribute-name box-title" title="({{localize 'ACKS.exploration.sd.abrev'}}) {{localize 'ACKS.exploration.sd.long'}}"><a>{{ localize "ACKS.exploration.sd.short" }}</a>
     </h4>
     <div class="attribute-value">
-      <input name="data.exploration.sd" type="text" value="{{data.data.exploration.sd}}" value="18"  placeholder="0" data-dtype="String" />
+      <input name="system.exploration.sd" type="text" value="{{system.exploration.sd}}" value="18"  placeholder="0" data-dtype="String" />
     </div>
   </li>
   <li class="attribute flexrow" data-exploration="ft">
     <h4 class="attribute-name box-title" title="({{localize 'ACKS.exploration.ft.abrev'}}) {{localize 'ACKS.exploration.ft.long'}}"><a>{{ localize "ACKS.exploration.ft.short" }}</a>
     </h4>
     <div class="attribute-value">
-      <input name="data.exploration.ft" type="text" value="{{data.data.exploration.ft}}" value="18" placeholder="0" data-dtype="String" />
+      <input name="system.exploration.ft" type="text" value="{{system.exploration.ft}}" value="18" placeholder="0" data-dtype="String" />
     </div>
   </li>
 </ul>
@@ -41,7 +41,7 @@
     {{#each abilities as |item|}}
     <li class="item-entry">
       <div class="item flexrow" data-item-id="{{item._id}}">
-        <div class="item-name {{#if item.data.roll}}item-rollable{{/if}} flexrow">
+        <div class="item-name {{#if item.roll}}item-rollable{{/if}} flexrow">
           <div class="item-image" style="background-image: url({{item.img}})"></div>
           <a>
             <h4 title="{{item.name}}">

--- a/src/templates/actors/partials/character-attributes-tab.html
+++ b/src/templates/actors/partials/character-attributes-tab.html
@@ -13,7 +13,7 @@
                 <h4 class="attribute-name box-title" title="{{ localize 'ACKS.scores.str.long' }}">
                     <a>{{ localize "ACKS.scores.str.short" }}</a></h4>
                 <div class="attribute-value">
-                    <input name="data.scores.str.value" type="text" value="{{data.data.scores.str.value}}" placeholder="0"
+                    <input name="system.scores.str.value" type="text" value="{{system.scores.str.value}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
             </li>
@@ -21,7 +21,7 @@
                 <h4 class="attribute-name box-title" title="{{ localize 'ACKS.scores.int.long' }}">
                     <a>{{ localize "ACKS.scores.int.short" }}</a></h4>
                 <div class="attribute-value">
-                    <input name="data.scores.int.value" type="text" value="{{data.data.scores.int.value}}" placeholder="0"
+                    <input name="system.scores.int.value" type="text" value="{{system.scores.int.value}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
             </li>
@@ -29,7 +29,7 @@
                 <h4 class="attribute-name box-title" title="{{ localize 'ACKS.scores.wis.long' }}">
                     <a>{{ localize "ACKS.scores.wis.short" }}</a></h4>
                 <div class="attribute-value">
-                    <input name="data.scores.wis.value" type="text" value="{{data.data.scores.wis.value}}" placeholder="0"
+                    <input name="system.scores.wis.value" type="text" value="{{system.scores.wis.value}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
             </li>
@@ -37,7 +37,7 @@
                 <h4 class="attribute-name box-title" title="{{ localize 'ACKS.scores.dex.long' }}">
                     <a>{{ localize "ACKS.scores.dex.short" }}</a></h4>
                 <div class="attribute-value">
-                    <input name="data.scores.dex.value" type="text" value="{{data.data.scores.dex.value}}" placeholder="0"
+                    <input name="system.scores.dex.value" type="text" value="{{system.scores.dex.value}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
             </li>
@@ -45,7 +45,7 @@
                 <h4 class="attribute-name box-title" title="{{ localize 'ACKS.scores.con.long' }}">
                     <a>{{ localize "ACKS.scores.con.short" }}</a></h4>
                 <div class="attribute-value">
-                    <input name="data.scores.con.value" type="text" value="{{data.data.scores.con.value}}" placeholder="0"
+                    <input name="system.scores.con.value" type="text" value="{{system.scores.con.value}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
             </li>
@@ -53,7 +53,7 @@
                 <h4 class="attribute-name box-title" title="{{ localize 'ACKS.scores.cha.long' }}">
                     <a>{{ localize "ACKS.scores.cha.short" }}</a></h4>
                 <div class="attribute-value">
-                    <input name="data.scores.cha.value" type="text" value="{{data.data.scores.cha.value}}" placeholder="0"
+                    <input name="system.scores.cha.value" type="text" value="{{system.scores.cha.value}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
             </li>
@@ -63,25 +63,25 @@
     <div class="resources">
         <div class="flexrow">
             <div class="health">
-                <input class="health-value health-top" name="data.hp.value" type="text" value="{{data.data.hp.value}}"
+                <input class="health-value health-top" name="system.hp.value" type="text" value="{{system.hp.value}}"
                     data-dtype="Number" placeholder="0" title="{{localize 'ACKS.Health'}}" />
-                <input class="health-value health-bottom" name="data.hp.max" type="text" value="{{data.data.hp.max}}"
+                <input class="health-value health-bottom" name="system.hp.max" type="text" value="{{system.hp.max}}"
                     data-dtype="Number" placeholder="0" title="{{localize 'ACKS.HealthMax'}}" />
-                <div class="health-empty" style="height:{{counter false data.data.hp.value data.data.hp.max}}%"></div>
-                <div class="health-full" style="height:{{counter true data.data.hp.value data.data.hp.max}}%"></div>
+                <div class="health-empty" style="height:{{counter false system.hp.value system.hp.max}}%"></div>
+                <div class="health-full" style="height:{{counter true system.hp.value system.hp.max}}%"></div>
             </div>
             <div class="health armor-class">
                 {{#if config.ascendingAC}}
-                <div class="health-value health-top" title="{{localize 'ACKS.ArmorClass'}}">{{data.data.aac.value}}</div>
+                <div class="health-value health-top" title="{{localize 'ACKS.ArmorClass'}}">{{system.aac.value}}</div>
                 <div class="health-value health-bottom" title="{{localize 'ACKS.ArmorClassNaked'}}">
-                    {{data.data.aac.naked}}</div>
-                    {{#if data.data.aac.shield}}<div class="shield" title="{{localize 'ACKS.items.hasShield'}} ({{data.data.aac.shield}})"><i
+                    {{system.aac.naked}}</div>
+                    {{#if system.aac.shield}}<div class="shield" title="{{localize 'ACKS.items.hasShield'}} ({{system.aac.shield}})"><i
                             class="fas fa-shield-alt"></i></div>{{/if}}
                 {{else}}
-                <div class="health-value health-top" title="{{localize 'ACKS.ArmorClass'}}">{{data.data.ac.value}}</div>
+                <div class="health-value health-top" title="{{localize 'ACKS.ArmorClass'}}">{{system.ac.value}}</div>
                 <div class="health-value health-bottom" title="{{localize 'ACKS.ArmorClassNaked'}}">
-                    {{data.data.ac.naked}}</div>
-                    {{#if data.data.ac.shield}}<div class="shield" title="{{localize 'ACKS.items.hasShield'}} ({{data.data.ac.shield}})"><i
+                    {{system.ac.naked}}</div>
+                    {{#if system.ac.shield}}<div class="shield" title="{{localize 'ACKS.items.hasShield'}} ({{system.ac.shield}})"><i
                             class="fas fa-shield-alt"></i></div>{{/if}}
                 {{/if}}
             </div>
@@ -93,7 +93,7 @@
                         <a>{{ localize "ACKS.HitDiceShort" }}</a>
                     </h4>
                     <div class="attribute-value">
-                        <input name="data.hp.hd" type="text" value="{{data.data.hp.hd}}" placeholder=""
+                        <input name="system.hp.hd" type="text" value="{{system.hp.hd}}" placeholder=""
                             data-dtype="String" />
                     </div>
                 </li>
@@ -103,8 +103,8 @@
                         <a>{{ localize "ACKS.BHRShort" }}</a>
                     </h4>
                     <div class="attribute-value"
-                        title="Calculated from {{data.data.hp.max}} HP">
-                        {{data.data.hp.bhr}}
+                        title="Calculated from {{system.hp.max}} HP">
+                        {{system.hp.bhr}}
                     </div>
                 </li>
                 {{/if}}
@@ -113,8 +113,8 @@
                     <h4 class="attribute-name box-title" title="{{ localize 'ACKS.Initiative' }}">
                         {{ localize "ACKS.InitiativeShort" }}</h4>
                     <div class="attribute-value"
-                        title="{{localize 'ACKS.scores.dex.long'}}({{data.data.scores.dex.init}}) + {{localize 'ACKS.Modifier'}}({{data.data.initiative.mod}})">
-                        {{add data.data.scores.dex.init data.data.initiative.mod}}
+                        title="{{localize 'ACKS.scores.dex.long'}}({{system.scores.dex.init}}) + {{localize 'ACKS.Modifier'}}({{system.initiative.mod}})">
+                        {{add system.scores.dex.init system.initiative.mod}}
                     </div>
                 </li>
                 {{/if}}
@@ -127,8 +127,8 @@
                         <a>{{localize 'ACKS.MeleeShort'}}</a></h4>
                     <div class="flexrow">
                         <div class="attribute-value"
-                            title="{{localize 'ACKS.scores.str.long'}}({{data.data.scores.str.mod}}) + {{localize 'ACKS.Modifier'}}({{data.data.thac0.mod.melee}})">
-                            {{add data.data.scores.str.mod data.data.thac0.mod.melee}}
+                            title="{{localize 'ACKS.scores.str.long'}}({{system.s.str.mod}}) + {{localize 'ACKS.Modifier'}}({{system.thac0.mod.melee}})">
+                            {{add system.scores.str.mod system.thac0.mod.melee}}
                         </div>
                     </div>
                 </li>
@@ -138,7 +138,7 @@
                     </h4>
                     <div class="flexrow">
                         <div class="attribute-value">
-                            <input name="data.thac0.throw" type="text" value="{{data.data.thac0.throw}}" placeholder=""
+                            <input name="system.thac0.throw" type="text" value="{{system.thac0.throw}}" placeholder=""
                                 data-dtype="Number" +/>
                         </div>
                     </div>
@@ -149,7 +149,7 @@
                     </h4>
                     <div class="flexrow">
                         <div class="attribute-value">
-                            <input name="data.thac0.value" type="text" value="{{data.data.thac0.value}}" placeholder="0"
+                            <input name="system.thac0.value" type="text" value="{{system.thac0.value}}" placeholder="0"
                                 data-dtype="Number" />
                         </div>
                     </div>
@@ -160,8 +160,8 @@
                         <a>{{localize 'ACKS.MissileShort'}}</a></h4>
                     <div class="flexrow">
                         <div class="attribute-value"
-                            title="{{localize 'ACKS.scores.dex.long'}}({{data.data.scores.dex.mod}}) + {{localize 'ACKS.Modifier'}}({{data.data.thac0.mod.missile}})">
-                            {{add data.data.scores.dex.mod data.data.thac0.mod.missile}}
+                            title="{{localize 'ACKS.scores.dex.long'}}({{system.scores.dex.mod}}) + {{localize 'ACKS.Modifier'}}({{system.thac0.mod.missile}})">
+                            {{add system.scores.dex.mod system.thac0.mod.missile}}
                         </div>
                     </div>
                 </li>
@@ -174,7 +174,7 @@
                         {{localize 'ACKS.movement.overland.short'}}</h4>
                     <div class="flexrow">
                         <div class="attribute-value">
-                            {{divide data.data.movement.base 5}}
+                            {{divide system.movement.base 5}}
                         </div>
                     </div>
                 </li>
@@ -182,8 +182,8 @@
                     <h4 class="attribute-name box-title" title="{{ localize 'ACKS.movement.exploration.long' }}">
                         {{ localize "ACKS.movement.exploration.short" }}</h4>
                     <div class="attribute-value flexrow">
-                        <input name="data.movement.base" type="text" value="{{data.data.movement.base}}" placeholder="0"
-                            data-dtype="Number" {{#if data.data.config.movementAuto}}disabled{{/if}} />
+                        <input name="system.movement.base" type="text" value="{{system.movement.base}}" placeholder="0"
+                            data-dtype="Number" {{#if system.config.movementAuto}}disabled{{/if}} />
                     </div>
                 </li>
                 <li class="attribute attribute-secondaries">
@@ -191,7 +191,7 @@
                         {{localize 'ACKS.movement.encounter.short'}}</h4>
                     <div class="flexrow">
                         <div class="attribute-value">
-                            {{divide data.data.movement.base 3}}
+                            {{divide system.movement.base 3}}
                         </div>
                     </div>
                 </li>
@@ -205,43 +205,43 @@
                 <h4 class="attribute-name box-title">
                     <a>{{ localize "ACKS.saves.paralysis.long" }}</a></h4>
                 <div class="attribute-value">
-                    <input name="data.saves.paralysis.value" type="text" value="{{data.data.saves.paralysis.value}}"
+                    <input name="system.saves.paralysis.value" type="text" value="{{system.saves.paralysis.value}}"
                         placeholder="0" data-dtype="Number" />
             </li>
             <li class="attribute saving-throw" data-save="death">
                 <h4 class="attribute-name box-title">
                     <a>{{ localize "ACKS.saves.death.long" }}</a></h4>
                 <div class="attribute-value">
-                    <input name="data.saves.death.value" type="text" value="{{data.data.saves.death.value}}" placeholder="0"
+                    <input name="system.saves.death.value" type="text" value="{{system.saves.death.value}}" placeholder="0"
                         data-dtype="Number" />
             </li>
             <li class="attribute saving-throw" data-save="breath">
                 <h4 class="attribute-name box-title">
                     <a>{{ localize "ACKS.saves.breath.long" }}</a></h4>
                 <div class="attribute-value">
-                    <input name="data.saves.breath.value" type="text" value="{{data.data.saves.breath.value}}"
+                    <input name="system.saves.breath.value" type="text" value="{{system.saves.breath.value}}"
                         placeholder="0" data-dtype="Number" />
             </li>
             <li class="attribute saving-throw" data-save="wand">
                 <h4 class="attribute-name box-title">
                     <a>{{ localize "ACKS.saves.wand.long" }}</a></h4>
                 <div class="attribute-value">
-                    <input name="data.saves.wand.value" type="text" value="{{data.data.saves.wand.value}}" placeholder="0"
+                    <input name="system.saves.wand.value" type="text" value="{{system.saves.wand.value}}" placeholder="0"
                         data-dtype="Number" />
             </li>
             <li class="attribute saving-throw" data-save="spell">
                 <h4 class="attribute-name box-title">
                     <a>{{ localize "ACKS.saves.spell.long" }}</a></h4>
                 <div class="attribute-value">
-                    <input name="data.saves.spell.value" type="text" value="{{data.data.saves.spell.value}}"
+                    <input name="system.saves.spell.value" type="text" value="{{system.saves.spell.value}}"
                         placeholder="0" />
             </li>
             {{#unless config.removeMagicBonus}}
             <li class="attribute saving-throw">
                 <h4 class="attribute-name box-title" title="{{ localize 'ACKS.saves.magic.long' }}">
                     {{ localize "ACKS.saves.magic.long"}}</h4>
-                <div class="attribute-value flat" title="{{localize 'ACKS.scores.wis.long'}}({{data.data.scores.wis.mod}})">
-                    {{mod data.data.scores.wis.mod}}
+                <div class="attribute-value flat" title="{{localize 'ACKS.scores.wis.long'}}({{system.scores.wis.mod}})">
+                    {{mod system.scores.wis.mod}}
                 </div>
             </li>
             {{/unless}}

--- a/src/templates/actors/partials/character-header.html
+++ b/src/templates/actors/partials/character-header.html
@@ -4,36 +4,36 @@
     <input name="name" type="text" value="{{actor.name}}" placeholder="{{localize 'ACKS.details.name'}}" data-dtype="String" />
   </h1>
   <ul class="summary flexrow">
-    {{#if data.data.retainer.enabled}}
+    {{#if system.retainer.enabled}}
     <li>
-      <input type="text" name="data.retainer.wage" value="{{data.data.retainer.wage}}" data-dtype="String"
+      <input type="text" name="system.retainer.wage" value="{{system.retainer.wage}}" data-dtype="String"
          />
       <label>{{localize 'ACKS.RetainerWage'}}</label>
     </li>
     {{else}}
     <li>
-      <input type="text" name="data.details.title" value="{{data.data.details.title}}" data-dtype="String"
+      <input type="text" name="system.details.title" value="{{system.details.title}}" data-dtype="String"
          />
       <label>{{localize 'ACKS.details.title'}}</label>
     </li>
     {{/if}}
     <li>
-      <input type="text" name="data.details.alignment" value="{{data.data.details.alignment}}" data-dtype="String"
+      <input type="text" name="system.details.alignment" value="{{system.details.alignment}}" data-dtype="String"
          />
       <label>{{localize 'ACKS.details.alignment'}}</label>
     </li>
-    {{#if data.data.retainer.enabled}}
+    {{#if system.retainer.enabled}}
     <li class="flexrow check-field">
       <div class="check morale-check" title="{{localize 'ACKS.roll.morale'}}"><a><i class="fas fa-dice"></i></a></div>
       <div>
-        <input type="text" name="data.details.morale" value="{{data.data.details.morale}}" />
+        <input type="text" name="system.details.morale" value="{{system.details.morale}}" />
         <label>{{localize 'ACKS.details.morale'}}</label>  
       </div>
     </li>
     <li class="flex2 check-field" data-stat="lr">
       <div class="check loyalty-check" title="{{localize 'ACKS.loyalty.check'}}"><a><i class="fas fa-dice"></i></a></div>
       <div class="attribute-value">
-        <input name="data.retainer.loyalty" type="text" value="{{data.data.retainer.loyalty}}" placeholder="Loyal" data-dtype="String" />
+        <input name="system.retainer.loyalty" type="text" value="{{system.retainer.loyalty}}" placeholder="Loyal" data-dtype="String" />
         <label>{{localize 'ACKS.Loyalty'}}</label>  
       </div>
     </li>
@@ -41,21 +41,21 @@
   </ul>
   <ul class="summary flexrow">
     <li class="flex3">
-      <input type="text" name="data.details.class" value="{{data.data.details.class}}" data-dtype="String"
+      <input type="text" name="system.details.class" value="{{system.details.class}}" data-dtype="String"
         />
       <label>{{localize 'ACKS.details.class'}}</label>
     </li>
-    <li class="{{#if (gt data.data.details.xp.value data.data.details.xp.next)}}notify{{/if}}">
-      <input type="text" name="data.details.level" value="{{data.data.details.level}}" data-dtype="Number"
+    <li class="{{#if (gt system.details.xp.value system.details.xp.next)}}notify{{/if}}">
+      <input type="text" name="system.details.level" value="{{system.details.level}}" data-dtype="Number"
          />
       <label>{{localize 'ACKS.details.level'}}</label>
     </li>
     <li class="flex2">
-      <input type="text" name="data.details.xp.value" value="{{data.data.details.xp.value}}" data-dtype="Number"
+      <input type="text" name="system.details.xp.value" value="{{system.details.xp.value}}" data-dtype="Number"
          />
       <label>{{localize 'ACKS.details.experience.base'}}</label>
-      {{#if data.data.details.xp.bonus}}
-      <span class="xp-bonus">+{{data.data.details.xp.bonus}}%</span>
+      {{#if system.details.xp.bonus}}
+      <span class="xp-bonus">+{{system.details.xp.bonus}}%</span>
       {{/if}}
     </li>
   </ul>

--- a/src/templates/actors/partials/character-inventory-tab.html
+++ b/src/templates/actors/partials/character-inventory-tab.html
@@ -23,23 +23,23 @@
             </a>
           </div>
           <div class="icon-row flexrow">
-            {{#each item.tags as |tag|}}
+            {{#each item.system.tags as |tag|}}
               {{#if (getTagIcon tag.value)}}
                 <img title="{{tag.title}}" src="{{getTagIcon tag.value}}" width="24" height="24"/>
               {{/if}}
             {{/each}}
-            {{#each item.tags as |tag|}}
+            {{#each item.system.tags as |tag|}}
             {{#unless (getTagIcon tag.value)}}
               <span title="{{tag.title}}">{{tag.value}}{{#unless @last}},{{/unless}}</span>
             {{/unless}}
             {{/each}}
           </div>
           <div class="field-short">
-            {{#if (eq @root.config.encumbrance "detailed")}}{{item.weight}}{{else}}_{{/if}}
+            {{#if (eq @root.config.encumbrance "detailed")}}{{item.system.weight}}{{else}}_{{/if}}
           </div>
           <div class="item-controls">
             {{#if ../owner}}
-            <a class="item-control item-toggle {{#unless item.equipped}}item-unequipped{{/unless}}"
+            <a class="item-control item-toggle {{#unless item.system.equipped}}item-unequipped{{/unless}}"
               title='{{localize "ACKS.items.Equip"}}'>
               <i class="fas fa-tshirt"></i>
             </a>
@@ -110,7 +110,7 @@
       <div class="item-caret"><i class="fas fa-caret-down"></i></div>
       <div class="item-name">{{localize "ACKS.items.Misc"}}</div>
       <div class="field-short"><i class="fas fa-hashtag"></i></div>
-      <div class="field-short"></div>
+      <div class="field-short"><i class="fas fa-weight-hanging"></i></div>
       <div class="item-controls">
         <a class="item-control item-create" data-type="item" title="{{localize 'ACKS.Add'}}"><i
             class="fa fa-plus"></i></a>
@@ -133,7 +133,9 @@
             <input value="{{item.system.quantity.value}}" type="text"
               placeholder="0" />{{#if item.system.quantity.max}}<span>/{{item.system.quantity.max}}</span>{{/if}}
           </div>
-          <div class="field-short"></div>
+          <div class="field-short">
+            {{#if (eq @root.config.encumbrance "detailed")}}{{item.system.weight}}{{else}}_{{/if}}
+          </div>
           <div class="item-controls">
             {{#if ../owner}}
             <a class="item-control item-edit" title='{{localize "ACKS.Edit"}}'><i class="fas fa-edit"></i></a>

--- a/src/templates/actors/partials/character-inventory-tab.html
+++ b/src/templates/actors/partials/character-inventory-tab.html
@@ -23,23 +23,23 @@
             </a>
           </div>
           <div class="icon-row flexrow">
-            {{#each item.data.tags as |tag|}}
+            {{#each item.tags as |tag|}}
               {{#if (getTagIcon tag.value)}}
                 <img title="{{tag.title}}" src="{{getTagIcon tag.value}}" width="24" height="24"/>
               {{/if}}
             {{/each}}
-            {{#each item.data.tags as |tag|}}
+            {{#each item.tags as |tag|}}
             {{#unless (getTagIcon tag.value)}}
               <span title="{{tag.title}}">{{tag.value}}{{#unless @last}},{{/unless}}</span>
             {{/unless}}
             {{/each}}
           </div>
           <div class="field-short">
-            {{#if (eq @root.config.encumbrance "detailed")}}{{item.data.weight}}{{else}}_{{/if}}
+            {{#if (eq @root.config.encumbrance "detailed")}}{{item.weight}}{{else}}_{{/if}}
           </div>
           <div class="item-controls">
             {{#if ../owner}}
-            <a class="item-control item-toggle {{#unless item.data.equipped}}item-unequipped{{/unless}}"
+            <a class="item-control item-toggle {{#unless item.equipped}}item-unequipped{{/unless}}"
               title='{{localize "ACKS.items.Equip"}}'>
               <i class="fas fa-tshirt"></i>
             </a>
@@ -81,17 +81,17 @@
           </div>
           <div class="field-short">
             {{#if @root.config.ascendingAC}}
-            {{item.data.aac.value}}
+            {{item.system.aac.value}}
             {{else}}
-            {{item.data.ac.value}}
+            {{item.system.ac.value}}
             {{/if}}
           </div>
           <div class="field-short">
-            {{#if (eq @root.config.encumbrance "detailed")}}{{item.data.weight}}{{else}}_{{/if}}
+            {{#if (eq @root.config.encumbrance "detailed")}}{{item.system.weight}}{{else}}_{{/if}}
           </div>
           <div class="item-controls">
             {{#if ../owner}}
-            <a class="item-control item-toggle {{#unless item.data.equipped}}item-unequipped{{/unless}}"
+            <a class="item-control item-toggle {{#unless item.system.equipped}}item-unequipped{{/unless}}"
               title='{{localize "ACKS.items.Equip"}}'>
               <i class="fas fa-tshirt"></i>
             </a>
@@ -118,7 +118,7 @@
     </li>
     <ol class="item-list">
       {{#each owned.items as |item|}}
-      {{#unless item.data.treasure}}
+      {{#unless item.system.treasure}}
       <li class="item-entry">
         <div class="item flexrow" data-item-id="{{item._id}}">
           <div class="item-name flexrow">
@@ -130,8 +130,8 @@
             </a>
           </div>
           <div class="field-short quantity">
-            <input value="{{item.data.quantity.value}}" type="text"
-              placeholder="0" />{{#if item.data.quantity.max}}<span>/{{item.data.quantity.max}}</span>{{/if}}
+            <input value="{{item.system.quantity.value}}" type="text"
+              placeholder="0" />{{#if item.system.quantity.max}}<span>/{{item.system.quantity.max}}</span>{{/if}}
           </div>
           <div class="field-short"></div>
           <div class="item-controls">
@@ -151,7 +151,7 @@
     <li class="item-titles flexrow">
       <div class="item-caret"><i class="fas fa-caret-down"></i></div>
       <div class="item-name">{{localize "ACKS.items.Treasure"}}</div>
-      <div class="field-long">{{roundTreas data.data.treasure}} <i class="fas fa-circle"></i></div>
+      <div class="field-long">{{roundTreas system.treasure}} <i class="fas fa-circle"></i></div>
       <div class="field-short"><i class="fas fa-hashtag"></i></div>
       <div class="field-short"><i class="fas fa-weight-hanging"></i></div>
       <div class="item-controls">
@@ -161,7 +161,7 @@
     </li>
     <ol class="item-list">
       {{#each owned.items as |item|}}
-      {{#if item.data.treasure}}
+      {{#if item.system.treasure}}
       <li class="item-entry">
         <div class="item flexrow" data-item-id="{{item._id}}">
           <div class="item-name flexrow">
@@ -172,13 +172,13 @@
               </h4>
             </a>
           </div>
-          <div class="field-long">{{multround item.data.quantity.value item.data.cost}}</div>
+          <div class="field-long">{{multround item.system.quantity.value item.system.cost}}</div>
           <div class="field-short quantity">
-            <input value="{{item.data.quantity.value}}" type="text"
-              placeholder="0" />{{#if item.data.quantity.max}}<span>/{{item.data.quantity.max}}</span>{{/if}}
+            <input value="{{item.system.quantity.value}}" type="text"
+              placeholder="0" />{{#if item.system.quantity.max}}<span>/{{item.system.quantity.max}}</span>{{/if}}
           </div>
           <div class="field-short">
-            {{#if (eq @root.config.encumbrance "detailed")}}{{mult item.data.quantity.value item.data.weight}}{{else}}_{{/if}}
+            {{#if (eq @root.config.encumbrance "detailed")}}{{mult item.system.quantity.value item.system.weight}}{{else}}_{{/if}}
           </div>
           <div class="item-controls">
             {{#if ../owner}}
@@ -194,7 +194,7 @@
   </div>
 </section>
 <section>
-  {{#with data.data.encumbrance}}
+  {{#with system.encumbrance}}
   <div class="encumbrance {{#if encumbered}}encumbered{{/if}}">
     <span class="encumbrance-bar" style="width:{{pct}}%"></span>
     <span class="encumbrance-label">{{value}} / {{max}}</span>

--- a/src/templates/actors/partials/character-notes-tab.html
+++ b/src/templates/actors/partials/character-notes-tab.html
@@ -26,7 +26,7 @@
                 </ol>
             </div>
             <div class="flex3 description">
-                <div class="item-titles">{{localize "ACKS.category.biography"}}</div>
+                <div class="item-titles">{{localize "ACKS.category.description"}}</div>
                 <div>
                     {{editor richBiography target="system.details.biography"
                     button=true editable=editable}}

--- a/src/templates/actors/partials/character-notes-tab.html
+++ b/src/templates/actors/partials/character-notes-tab.html
@@ -26,9 +26,9 @@
                 </ol>
             </div>
             <div class="flex3 description">
-                <div class="item-titles">{{localize "ACKS.category.description"}}</div>
+                <div class="item-titles">{{localize "ACKS.category.biography"}}</div>
                 <div>
-                    {{editor richDescription target="system.details.description"
+                    {{editor richBiography target="system.details.biography"
                     button=true editable=editable}}
                 </div>
             </div>

--- a/src/templates/actors/partials/character-notes-tab.html
+++ b/src/templates/actors/partials/character-notes-tab.html
@@ -12,7 +12,7 @@
                     </div>
                 </div>
                 <ol>
-                    {{#each data.data.languages.value as |lang|}}
+                    {{#each system.languages.value as |lang|}}
                     <li class="item flexrow" data-lang="{{lang}}">
                         <div class="item-name">
                             {{lang}}
@@ -28,8 +28,8 @@
             <div class="flex3 description">
                 <div class="item-titles">{{localize "ACKS.category.description"}}</div>
                 <div>
-                    {{editor content=data.data.details.description target="data.details.description"
-                button=true owner=owner editable=editable}}
+                    {{editor richDescription target="system.details.description"
+                    button=true editable=editable}}
                 </div>
             </div>
         </div>
@@ -37,8 +37,8 @@
     <div class="inventory notes">
         <div class="item-titles">{{localize "ACKS.category.notes"}}</div>
         <div class="resizable-editor" data-editor-size="140">
-            {{editor content=data.data.details.notes target="data.details.notes"
-            button=true owner=owner editable=editable}}
+            {{editor richNotes target="system.details.notes"
+            button=true editable=editable}}
         </div>
     </div>
 </section>

--- a/src/templates/actors/partials/character-spells-tab.html
+++ b/src/templates/actors/partials/character-spells-tab.html
@@ -14,9 +14,9 @@
       <div class="item-name">{{localize "ACKS.spells.Level"}} {{id}}</div>
       <div class="field-short">{{localize 'ACKS.spells.Slots'}}</div>
       <div class="field-long flexrow">
-        <input type="text" value="{{lookup @root.slots.used @key}}" name="data.spells.{{id}}.value" data-dtype="Number"
-          placeholder="0" disabled>/<input type="text" value="{{lookup (lookup ../actor.data.data.spells @key) 'max'}}"
-          name="data.spells.{{id}}.max" data-dtype="Number" placeholder="0"></div>
+        <input type="text" value="{{lookup @root.slots.used @key}}" name="system.spells.{{id}}.value" data-dtype="Number"
+          placeholder="0" disabled>/<input type="text" value="{{lookup (lookup ../actor.system.spells @key) 'max'}}"
+          name="system.spells.{{id}}.max" data-dtype="Number" placeholder="0"></div>
       <div class="item-controls">
         <a class="item-control item-create" data-type="spell" data-lvl="{{id}}" title="{{localize 'ACKS.Add'}}"><i
             class="fa fa-plus"></i></a>
@@ -35,7 +35,7 @@
             </a>
           </div>
           <div class="field-short memorize flexrow">
-            <input type="text" value="{{item.data.data.cast}}" data-dtype="Number" placeholder="0" data-field="cast"
+            <input type="text" value="{{item.system.cast}}" data-dtype="Number" placeholder="0" data-field="cast"
                    title="{{localize 'ACKS.spells.Cast'}}"></div>
           <div class="item-controls">
             {{#if ../../owner}}

--- a/src/templates/actors/partials/monster-attributes-tab.html
+++ b/src/templates/actors/partials/monster-attributes-tab.html
@@ -5,10 +5,10 @@
                 <h4 class="attribute-name box-title" title="{{localize 'ACKS.Health'}}">{{ localize "ACKS.HealthShort" }}
                     <a class="hp-roll"><i class="fas fa-dice"></i></a></h4>
                 <div class="attribute-value flexrow">
-                    <input name="data.hp.value" type="text" value="{{data.data.hp.value}}" data-dtype="Number"
+                    <input name="system.hp.value" type="text" value="{{system.hp.value}}" data-dtype="Number"
                         placeholder="0" />
                     <span class="sep"> / </span>
-                    <input name="data.hp.max" type="text" value="{{data.data.hp.max}}" data-dtype="Number" placeholder="0" />
+                    <input name="system.hp.max" type="text" value="{{system.hp.max}}" data-dtype="Number" placeholder="0" />
                 </div>
             </li>
             <li class="attribute hit-dice">
@@ -16,7 +16,7 @@
                     <a>{{ localize "ACKS.HitDiceShort" }}</a>
                 </h4>
                 <div class="attribute-value">
-                    <input name="data.hp.hd" type="text" value="{{data.data.hp.hd}}" data-dtype="String" />
+                    <input name="system.hp.hd" type="text" value="{{system.hp.hd}}" data-dtype="String" />
                 </div>
             </li>
             <li class="attribute">
@@ -24,14 +24,14 @@
                 <h4 class="attribute-name box-title" title="{{ localize 'ACKS.ArmorClass' }}">
                     {{ localize "ACKS.AscArmorClassShort" }}</h4>
                 <div class="attribute-value">
-                    <input name="data.aac.value" type="text" value="{{data.data.aac.value}}" data-dtype="Number"
+                    <input name="system.aac.value" type="text" value="{{system.aac.value}}" data-dtype="Number"
                         placeholder="10" data-dtype="Number" />
                 </div>
                 {{else}}
                 <h4 class="attribute-name box-title" title="{{ localize 'ACKS.ArmorClass' }}">
                     {{ localize "ACKS.ArmorClassShort" }}</h4>
                 <div class="attribute-value">
-                    <input name="data.ac.value" type="text" value="{{data.data.ac.value}}" data-dtype="Number"
+                    <input name="system.ac.value" type="text" value="{{system.ac.value}}" data-dtype="Number"
                         placeholder="9" data-dtype="Number" />
                 </div>
                 {{/if}}
@@ -41,25 +41,25 @@
                 <h4 class="attribute-name box-title" title="{{localize 'ACKS.AB'}}"><a>{{ localize "ACKS.ABShort" }}</a>
                 </h4>
                 <div class="attribute-value">
-                    <input name="data.thac0.throw" type="text" value="{{data.data.thac0.throw}}" placeholder=""
+                    <input name="system.thac0.throw" type="text" value="{{system.thac0.throw}}" placeholder=""
                         data-dtype="Number" />
                 </div>
                 {{else}}
                 <h4 class="attribute-name box-title" title="{{localize 'ACKS.Thac0'}}"><a>{{ localize "ACKS.Thac0" }}</a>
                 </h4>
                 <div class="attribute-value">
-                    <input name="data.thac0.value" type="text" value="{{data.data.thac0.value}}" placeholder="0"
+                    <input name="system.thac0.value" type="text" value="{{system.thac0.value}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
                 {{/if}}
             </li>
-            {{#if data.data.retainer.enabled}}
+            {{#if system.ner.enabled}}
             <li class="attribute">
                 <h4 class="attribute-name box-title" title="{{ localize 'ACKS.Loyalty' }}">
                     {{ localize "ACKS.LoyaltyShort" }}
                 </h4>
                 <div class="attribute-value">
-                    <input name="data.retainer.loyalty" type="text" value="{{data.data.retainer.loyalty}}" placeholder="0"
+                    <input name="system.retainer.loyalty" type="text" value="{{system.ner.loyalty}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
             </li>
@@ -69,7 +69,7 @@
                     {{ localize "ACKS.movement.short" }}
                 </h4>
                 <div class="attribute-value">
-                    <input name="data.movement.base" type="text" value="{{data.data.movement.base}}" placeholder="0"
+                    <input name="system.movement.base" type="text" value="{{system.ent.base}}" placeholder="0"
                         data-dtype="Number" />
                 </div>
             </li>
@@ -94,8 +94,8 @@
                     {{#each abilities as |item|}}
                     <li class="item-entry">
                         <div class="item flexrow" data-item-id="{{item._id}}">
-                            <div class="item-pattern" title="{{localize 'ACKS.items.pattern'}}" style="background:linear-gradient(0.25turn, {{item.data.pattern}}, transparent)"></div>
-                            <div class="item-name {{#if item.data.data.roll}}item-rollable{{/if}} flexrow">
+                            <div class="item-pattern" title="{{localize 'ACKS.items.pattern'}}" style="background:linear-gradient(0.25turn, {{item.system.pattern}}, transparent)"></div>
+                            <div class="item-name {{#if item.system.roll}}item-rollable{{/if}} flexrow">
                                 <div class="item-image" style="background-image: url({{item.img}})"></div>
                                 <h4 title="{{item.name}}">
                                     {{item.name~}}
@@ -119,7 +119,7 @@
                     <li class="item-entry">
                         <div class="item flexrow" data-item-id="{{item._id}}">
                             {{#if (eq item.type 'weapon')}}
-                            <div class="item-pattern" title="{{localize 'ACKS.items.pattern'}}" style="background:linear-gradient(0.25turn, {{item.data.pattern}}, transparent)"></div>
+                            <div class="item-pattern" title="{{localize 'ACKS.items.pattern'}}" style="background:linear-gradient(0.25turn, {{item.system.pattern}}, transparent)"></div>
                             {{/if}}
                             <div class="item-name {{#if (eq item.type 'weapon')}}item-rollable{{/if}}  flexrow">
                                 <div class="item-image" style="background-image: url({{item.img}})"></div>
@@ -129,10 +129,10 @@
                             </div>
                             {{#if (eq item.type 'weapon')}}
                             <div class="field-long counter flexrow">
-                                <input type="text" value="{{item.data.counter.value}}" data-dtype="Number"
+                                <input type="text" value="{{item.system.counter.value}}" data-dtype="Number"
                                     placeholder="0" data-field="value" title="{{localize 'ACKS.items.roundAttacks'}}">
                                 /
-                                <input type="text" value="{{item.data.counter.max}}" data-field="max"
+                                <input type="text" value="{{item.system.counter.max}}" data-field="max"
                                     data-dtype="Number" placeholder="0"
                                     title="{{localize 'ACKS.items.roundAttacksMax'}}"></div>
                             {{/if}}
@@ -157,7 +157,7 @@
                 <li class="attacks-description">
                     {{#unless isNew}}
                     <label>{{ localize "ACKS.movement.details" }}</label>
-                    <input name="data.movement.value" type="text" value="{{data.data.movement.value}}" data-dtype="String" />
+                    <input name="system.movement.value" type="text" value="{{system.ent.value}}" data-dtype="String" />
                     {{else}}
                     <button data-action="generate-saves">{{localize "ACKS.dialog.generateSaves"}}</button>
                     {{/unless}}
@@ -166,35 +166,35 @@
                     <h4 class="attribute-name box-title">
                         <a>{{ localize "ACKS.saves.death.long" }}</a></h4>
                     <div class="attribute-value">
-                        <input name="data.saves.death.value" type="text" value="{{data.data.saves.death.value}}"
+                        <input name="system.saves.death.value" type="text" value="{{system.saves.death.value}}"
                             placeholder="0" data-dtype="Number" />
                 </li>
                 <li class="attribute saving-throw" data-save="wand">
                     <h4 class="attribute-name box-title">
                         <a>{{ localize "ACKS.saves.wand.long" }}</a></h4>
                     <div class="attribute-value">
-                        <input name="data.saves.wand.value" type="text" value="{{data.data.saves.wand.value}}"
+                        <input name="system.saves.wand.value" type="text" value="{{system.saves.wand.value}}"
                             placeholder="0" data-dtype="Number" />
                 </li>
                 <li class="attribute saving-throw" data-save="paralysis">
                     <h4 class="attribute-name box-title">
                         <a>{{ localize "ACKS.saves.paralysis.long" }}</a></h4>
                     <div class="attribute-value">
-                        <input name="data.saves.paralysis.value" type="text" value="{{data.data.saves.paralysis.value}}"
+                        <input name="system.saves.paralysis.value" type="text" value="{{system.saves.paralysis.value}}"
                             placeholder="0" data-dtype="Number" />
                 </li>
                 <li class="attribute saving-throw" data-save="breath">
                     <h4 class="attribute-name box-title">
                         <a>{{ localize "ACKS.saves.breath.long" }}</a></h4>
                     <div class="attribute-value">
-                        <input name="data.saves.breath.value" type="text" value="{{data.data.saves.breath.value}}"
+                        <input name="system.saves.breath.value" type="text" value="{{system.saves.breath.value}}"
                             placeholder="0" data-dtype="Number" />
                 </li>
                 <li class="attribute saving-throw" data-save="spell">
                     <h4 class="attribute-name box-title">
                         <a>{{ localize "ACKS.saves.spell.long" }}</a></h4>
                     <div class="attribute-value">
-                        <input name="data.saves.spell.value" type="text" value="{{data.data.saves.spell.value}}"
+                        <input name="system.saves.spell.value" type="text" value="{{system.saves.spell.value}}"
                             placeholder="0" />
                 </li>
             </ul>

--- a/src/templates/actors/partials/monster-header.html
+++ b/src/templates/actors/partials/monster-header.html
@@ -6,26 +6,26 @@
   <ul class="summary flexrow">
     <li class="flex2 flexrow check-field">
       <div>
-        <input type="text" name="data.details.alignment" value="{{data.data.details.alignment}}" />
+        <input type="text" name="system.details.alignment" value="{{system.details.alignment}}" />
         <label>{{localize 'ACKS.details.alignment'}}</label>
       </div>
       <div class="check reaction-check" title="{{localize 'ACKS.roll.reaction'}}"><a><i class="fas fa-dice"></i></a></div>
     </li>
     <li class="flexrow check-field" data-check="dungeon">
       <div>
-        <input type="text" name="data.details.appearing.d" value="{{data.data.details.appearing.d}}" />
+        <input type="text" name="system.details.appearing.d" value="{{system.details.appearing.d}}" />
         <label>{{localize 'ACKS.details.appearing'}}</label>
       </div>
       <div class="check appearing-check" title="{{localize 'ACKS.roll.appearing'}}"><a><i class="fas fa-dice"></i></a></div>
     </li>
     <li class="flexrow check-field" data-check="wilderness">
-        (<div><input type="text" name="data.details.appearing.w" value="{{data.data.details.appearing.w}}" /></div>)
+        (<div><input type="text" name="system.details.appearing.w" value="{{system.details.appearing.w}}" /></div>)
       <div class="check appearing-check" title="{{localize 'ACKS.roll.appearing'}}"><a><i class="fas fa-dice"></i></a></div>
     </li>
     {{#if config.morale}}
     <li class="flexrow check-field">
       <div>
-        <input type="text" name="data.details.morale" value="{{data.data.details.morale}}" />
+        <input type="text" name="system.details.morale" value="{{system.details.morale}}" />
         <label>{{localize 'ACKS.details.morale'}}</label>  
       </div>
       <div class="check morale-check" title="{{localize 'ACKS.roll.morale'}}"><a><i class="fas fa-dice"></i></a></div>
@@ -34,11 +34,11 @@
   </ul>
   <ul class="summary flexrow">
     <li>
-      <input type="text" name="data.details.xp" value="{{data.data.details.xp}}" />
+      <input type="text" name="system.details.xp" value="{{system.details.xp}}" />
       <label>{{localize 'ACKS.details.experience.award'}}</label>
     </li>
     <li class="treasure-table" title="{{localize 'ACKS.details.treasureTableHint'}}">
-      <div>{{{data.data.details.treasure.link}}}</div>
+      <div>{{{system.details.treasure.link}}}</div>
       <label>{{localize 'ACKS.details.treasure'}}</label>
     </li>
   </ul>

--- a/src/templates/apps/party-select.html
+++ b/src/templates/apps/party-select.html
@@ -4,7 +4,7 @@
         <li class="form-group actor" data-actor-id="{{actor.id}}">
             <label>{{actor.name}}</label>
             <div class="form-fields">
-                <input type="checkbox" data-action="select-actor" name="{{key}}" data-dtype="Boolean" {{checked actor.data.flags.acks.party}}/>
+                <input type="checkbox" data-action="select-actor" name="{{key}}" data-dtype="Boolean" {{checked actor.system.flags.acks.party}}/>
             </div>
         </li>
     {{/each}}

--- a/src/templates/apps/party-sheet.html
+++ b/src/templates/apps/party-sheet.html
@@ -15,7 +15,7 @@
     {{/if}}
   </div>
   <ol class="actor-list">
-    {{#each data.documents as |actor|}} {{#if actor.data.flags.acks.party}}
+    {{#each system.documents as |actor|}} {{#if actor.flags.acks.party}}
     <li class="actor flexrow" data-actor-id="{{actor.id}}">
       <div class="field-img">
         <img src="{{actor.img}}" />
@@ -30,13 +30,13 @@
           </div>
           <div class="field-long" title="{{localize 'ACKS.Health'}}">
             <i class="fas fa-heart"></i>
-            {{actor.data.data.hp.value}}/{{actor.data.data.hp.max}}
+            {{actor.system.hp.value}}/{{actor.system.hp.max}}
           </div>
           <div class="field-short" title="{{localize 'ACKS.ArmorClass'}}">
             <i class="fas fa-shield-alt"></i>
-            {{#if @root.settings.ascending}}<strong>{{actor.data.data.aac.value}}</strong>
-            <sub>{{actor.data.data.aac.naked}}</sub>
-            {{else}}<strong>{{actor.data.data.ac.value}}</strong> <sub>{{actor.data.data.ac.naked}}</sub>
+            {{#if @root.settings.ascending}}<strong>{{actor.system.aac.value}}</strong>
+            <sub>{{actor.system.aac.naked}}</sub>
+            {{else}}<strong>{{actor.system.ac.value}}</strong> <sub>{{actor.system.ac.naked}}</sub>
             {{/if}}
           </div>
         </div>
@@ -44,40 +44,40 @@
           <div class="field-short" title="{{localize 'ACKS.Thac0'}}">
             <i class="fas fa-crosshairs"></i>
             {{#unless @root.settings.ascending}}
-            {{actor.data.data.thac0.value}}
+            {{actor.system.thac0.value}}
             {{else}}
-            {{actor.data.data.thac0.throw}}
+            {{actor.system.thac0.throw}}
             {{/unless}}
           </div>
-          {{#if (eq actor.data.type 'character')}}
+          {{#if (eq actor.type 'character')}}
           <div class="field-short" title="{{localize 'ACKS.Melee'}}">
             <i class="fas fa-fist-raised"></i>
-            {{add actor.data.data.scores.str.mod actor.data.data.thac0.mod.melee}}
+            {{add actor.system.scores.str.mod actor.system.thac0.mod.melee}}
           </div>
           <div class="field-short" title="{{localize 'ACKS.Missile'}}">
             <i class="fas fa-bullseye"></i>
-            {{add actor.data.data.scores.dex.mod actor.data.data.thac0.mod.missile}}
+            {{add actor.system.scores.dex.mod actor.system.thac0.mod.missile}}
           </div>
           {{/if}}
           <div class="field-short flex2">
             <i class="fas fa-shoe-prints" title="{{localize 'ACKS.movement.base'}}"></i>
-            <span title="{{localize 'ACKS.movement.encounter.long'}}">{{actor.data.data.movement.encounter}}</span> <sub
-              title="{{localize 'ACKS.movement.exploration.long'}}">{{actor.data.data.movement.base}}</sub>
+            <span title="{{localize 'ACKS.movement.encounter.long'}}">{{actor.system.movement.encounter}}</span> <sub
+              title="{{localize 'ACKS.movement.exploration.long'}}">{{actor.system.movement.base}}</sub>
           </div>
-          {{#if (eq actor.data.type 'character')}}
+          {{#if (eq actor.type 'character')}}
           <div class="field-short flex2">
             <i class="fas fa-weight-hanging" title="{{localize 'ACKS.Encumbrance'}}"></i>
-            {{roundWeight actor.data.data.encumbrance.value}}k
+            {{roundWeight actor.system.encumbrance.value}}k
           </div>
           {{/if}}
         </div>
         <div class="flexrow field-row">
           <div class="field-longer flexrow">
-            {{#each actor.data.data.saves as |s i|}}
+            {{#each actor.system.saves as |s i|}}
             <span title="{{lookup @root.config.saves_long i}}">{{lookup @root.config.saves_short i}} {{s.value}}</span>
             {{/each}}
-            {{#if (eq actor.data.type 'character')}}<span><i class="fas fa-magic"
-                title="{{localize 'ACKS.saves.magic.long'}}"></i>{{mod actor.data.data.scores.wis.mod}}</span>{{/if}}
+            {{#if (eq actor.type 'character')}}<span><i class="fas fa-magic"
+                title="{{localize 'ACKS.saves.magic.long'}}"></i>{{mod actor.system.scores.wis.mod}}</span>{{/if}}
           </div>
         </div>
       </div>

--- a/src/templates/chat/item-card.html
+++ b/src/templates/chat/item-card.html
@@ -6,7 +6,7 @@
     </header>
 
     <div class="card-content">
-        {{{data.description}}}
+        {{{system.description}}}
     </div>
 
     <div class="card-buttons">
@@ -22,19 +22,19 @@
         </button>
         {{/if}}
 
-        {{#if data.save}}
-        <button data-action="save" data-save="{{data.save}}" disabled>
-            {{lookup config.saves_long data.save}} - {{localize "ACKS.spells.Save"}}
+        {{#if system.save}}
+        <button data-action="save" data-save="{{system.save}}" disabled>
+            {{lookup config.saves_long system.save}} - {{localize "ACKS.spells.Save"}}
         </button>
         {{/if}}
 
-        {{#if data.roll}}
-        <button data-action="formula">{{ localize "ACKS.Roll"}} {{data.roll}} {{#if data.blindroll}}({{localize 'ACKS.items.BlindRoll'}}){{/if}}</button>
+        {{#if system.roll}}
+        <button data-action="formula">{{ localize "ACKS.Roll"}} {{system.roll}} {{#if system.blindroll}}({{localize 'ACKS.items.BlindRoll'}}){{/if}}</button>
         {{/if}}
     </div>
 
     <footer class="card-footer">
-        {{#each data.properties}}
+        {{#each system.properties}}
         <span>{{this}}</span>
         {{/each}}
     </footer>

--- a/src/templates/chat/roll-attack.html
+++ b/src/templates/chat/roll-attack.html
@@ -1,14 +1,14 @@
-<div class="acks chat-card item-card" data-actor-id="{{data.actor._id}}" data-item-id="{{data.item._id}}"
+<div class="acks chat-card item-card" data-actor-id="{{system.actor._id}}" data-item-id="{{system.item._id}}"
     {{#if tokenId}}data-token-id="{{tokenId}}" {{/if}}>
     <div class="acks chat-block">
         <div class="flexrow chat-header">
             <div class="chat-title">
                 <h2>{{title}}</h2>
             </div>
-            {{#if data.item}}
-            <div class="chat-img" style="background-image:url('{{data.item.img}}')"></div>
+            {{#if system.item}}
+            <div class="chat-img" style="background-image:url('{{system.item.img}}')"></div>
             {{else}}
-            <div class="chat-img" style="background-image:url('{{data.actor.img}}')"></div>
+            <div class="chat-img" style="background-image:url('{{system.actor.img}}')"></div>
             {{/if}}
         </div>
         {{#if result.victim}}
@@ -16,7 +16,7 @@
             vs {{result.victim}}
         </div>
         {{/if}}
-        <div class="blindable" data-blind="{{data.roll.blindroll}}">
+        <div class="blindable" data-blind="{{system.roll.blindroll}}">
             <div class="chat-details">
                 <div class="roll-result">{{{result.details}}}</div>
             </div>
@@ -26,10 +26,10 @@
                 <div class="roll-result"><b>{{localize 'ACKS.messages.InflictsDamage'}}</b></div>
             </div>
             <div class="damage-roll">{{{rollDamage}}}</div>
-            {{#if data.roll.save}}
+            {{#if system.roll.save}}
             <div class="card-buttons">
-                <button data-action="save" data-save="{{data.roll.save}}" disabled>
-                    {{lookup config.saves_long data.roll.save}} - {{localize "ACKS.spells.Save"}}
+                <button data-action="save" data-save="{{system.roll.save}}" disabled>
+                    {{lookup config.saves_long system.roll.save}} - {{localize "ACKS.spells.Save"}}
                 </button>
             </div>
             {{/if}}

--- a/src/templates/chat/roll-attack.html
+++ b/src/templates/chat/roll-attack.html
@@ -5,10 +5,10 @@
             <div class="chat-title">
                 <h2>{{title}}</h2>
             </div>
-            {{#if system.item}}
-            <div class="chat-img" style="background-image:url('{{system.item.img}}')"></div>
+            {{#if data.item}}
+            <div class="chat-img" style="background-image:url('{{data.item.img}}')"></div>
             {{else}}
-            <div class="chat-img" style="background-image:url('{{system.actor.img}}')"></div>
+            <div class="chat-img" style="background-image:url('{{data.actor.img}}')"></div>
             {{/if}}
         </div>
         {{#if result.victim}}
@@ -16,7 +16,7 @@
             vs {{result.victim}}
         </div>
         {{/if}}
-        <div class="blindable" data-blind="{{system.roll.blindroll}}">
+        <div class="blindable" data-blind="{{data.roll.blindroll}}">
             <div class="chat-details">
                 <div class="roll-result">{{{result.details}}}</div>
             </div>
@@ -26,10 +26,10 @@
                 <div class="roll-result"><b>{{localize 'ACKS.messages.InflictsDamage'}}</b></div>
             </div>
             <div class="damage-roll">{{{rollDamage}}}</div>
-            {{#if system.roll.save}}
+            {{#if data.roll.save}}
             <div class="card-buttons">
-                <button data-action="save" data-save="{{system.roll.save}}" disabled>
-                    {{lookup config.saves_long system.roll.save}} - {{localize "ACKS.spells.Save"}}
+                <button data-action="save" data-save="{{data.roll.save}}" disabled>
+                    {{lookup config.saves_long data.roll.save}} - {{localize "ACKS.spells.Save"}}
                 </button>
             </div>
             {{/if}}

--- a/src/templates/chat/roll-creation.html
+++ b/src/templates/chat/roll-creation.html
@@ -2,7 +2,7 @@
     <div class="acks chat-block">
         <div class="flexrow chat-header">
             <div class="chat-title"><h2>{{title}}</h2></div>
-            <div class="chat-img" style="background-image:url('{{data.actor.img}}')"></div>
+            <div class="chat-img" style="background-image:url('{{system.actor.img}}')"></div>
         </div>
         <div class="flexrow">
             <ol class="flex2">

--- a/src/templates/chat/roll-dialog.html
+++ b/src/templates/chat/roll-dialog.html
@@ -1,7 +1,7 @@
 <form class="acks roll-dialog">
-    {{#if system.rollData.details}}
+    {{#if data.rollData.details}}
     <div class="roll-details">
-        {{system.rollData.details}}
+        {{data.rollData.details}}
     </div>
     {{/if}}
     <div class="form-group">

--- a/src/templates/chat/roll-dialog.html
+++ b/src/templates/chat/roll-dialog.html
@@ -1,7 +1,7 @@
 <form class="acks roll-dialog">
-    {{#if data.rollData.details}}
+    {{#if system.rollData.details}}
     <div class="roll-details">
-        {{data.rollData.details}}
+        {{system.rollData.details}}
     </div>
     {{/if}}
     <div class="form-group">

--- a/src/templates/chat/roll-result.html
+++ b/src/templates/chat/roll-result.html
@@ -2,13 +2,13 @@
     <div class="acks chat-block">
         <div class="flexrow chat-header">
             <div class="chat-title"><h2>{{title}}</h2></div>
-            {{#if data.item}}
-            <div class="chat-img" style="background-image:url('{{data.item.img}}')"></div>
+            {{#if system.item}}
+            <div class="chat-img" style="background-image:url('{{system.item.img}}')"></div>
             {{else}}
-            <div class="chat-img" style="background-image:url('{{data.actor.img}}')"></div>
+            <div class="chat-img" style="background-image:url('{{system.actor.img}}')"></div>
             {{/if}}
         </div>
-        <div class="blindable" data-blind="{{data.roll.blindroll}}">
+        <div class="blindable" data-blind="{{system.roll.blindroll}}">
             {{#if result.details}}<div class="chat-details">{{{result.details}}}</div>{{/if}}
             {{#if result.isFailure}}<div class='roll-result roll-fail'><b>{{localize 'ACKS.Failure'}}</b> ({{result.target}})
             </div>{{/if}}

--- a/src/templates/chat/roll-result.html
+++ b/src/templates/chat/roll-result.html
@@ -2,10 +2,10 @@
     <div class="acks chat-block">
         <div class="flexrow chat-header">
             <div class="chat-title"><h2>{{title}}</h2></div>
-            {{#if system.item}}
-            <div class="chat-img" style="background-image:url('{{system.item.img}}')"></div>
+            {{#if data.item}}
+            <div class="chat-img" style="background-image:url('{{data.item.img}}')"></div>
             {{else}}
-            <div class="chat-img" style="background-image:url('{{system.actor.img}}')"></div>
+            <div class="chat-img" style="background-image:url('{{data.actor.img}}')"></div>
             {{/if}}
         </div>
         <div class="blindable" data-blind="{{system.roll.blindroll}}">

--- a/src/templates/items/ability-sheet.html
+++ b/src/templates/items/ability-sheet.html
@@ -13,20 +13,20 @@
         <div class="form-group block-input">
           <label>{{localize 'ACKS.abilities.Requirements'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.requirements" value="{{data.data.requirements}}" data-dtype="String" />
+            <input type="text" name="system.requirements" value="{{system.requirements}}" data-dtype="String" />
           </div>
         </div>
         <div class="form-group block-input">
           <label>{{localize 'ACKS.items.Roll'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.roll" value="{{data.data.roll}}" data-dtype="String" />
+            <input type="text" name="system.roll" value="{{system.roll}}" data-dtype="String" />
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'ACKS.items.RollType'}}</label>
           <div class="form-fields">
-            <select name="data.rollType">
-              {{#select data.data.rollType}}
+            <select name="system.rollType">
+              {{#select system.rollType}}
               {{#each config.roll_type as |t a|}}
               <option value="{{a}}">{{t}}</option>
               {{/each}}
@@ -37,20 +37,20 @@
         <div class="form-group">
           <label>{{localize 'ACKS.items.RollTarget'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.rollTarget" value="{{data.data.rollTarget}}" data-dtype="Number" />
+            <input type="text" name="system.rollTarget" value="{{system.rollTarget}}" data-dtype="Number" />
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'ACKS.items.BlindRoll'}}</label>
           <div class="form-fields">
-            <input type="checkbox" name="data.blindroll" value="{{data.data.blindroll}}" {{checked data.data.blindroll}}  data-dtype="Number"/>
+            <input type="checkbox" name="system.blindroll" value="{{system.blindroll}}" {{checked system.blindroll}}  data-dtype="Number"/>
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'ACKS.spells.Save'}}</label>
           <div class="form-fields">
-            <select name="data.save">
-              {{#select data.data.save}}
+            <select name="system.save">
+              {{#select system.save}}
               <option value=""></option>
               {{#each config.saves_short as |save a|}}
               <option value="{{a}}">{{save}}</option>
@@ -61,8 +61,8 @@
         </div>
       </div>
       <div class="description">
-        {{editor content=data.data.description target="data.description" button=true
-        owner=owner editable=editable}}
+        {{editor richDescription target="system.description"
+        button=true editable=editable}}
       </div>
     </div>
   </section>

--- a/src/templates/items/armor-sheet.html
+++ b/src/templates/items/armor-sheet.html
@@ -13,14 +13,14 @@
         <div class="form-group">
           <label>{{localize 'ACKS.items.ArmorAAC'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.aac.value" value="{{data.data.aac.value}}" data-dtype="Number" />
+            <input type="text" name="system.aac.value" value="{{system.aac.value}}" data-dtype="Number" />
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'ACKS.armor.type'}}</label>
           <div class="form-fields">
-            <select name="data.type">
-              {{#select data.data.type}}
+            <select name="system.type">
+              {{#select system.type}}
               <option value=""></option>
               {{#each config.armor as |armor a|}}
               <option value="{{a}}">{{armor}}</option>
@@ -32,19 +32,19 @@
         <div class="form-group">
           <label>{{localize 'ACKS.items.Cost'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.cost" value="{{data.data.cost}}" data-dtype="Number" />
+            <input type="text" name="system.cost" value="{{system.cost}}" data-dtype="Number" />
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'ACKS.items.Weight'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.weight" value="{{data.data.weight}}" data-dtype="Number" />
+            <input type="text" name="system.weight" value="{{system.weight}}" data-dtype="Number" />
           </div>
         </div>
       </div>
       <div class="description">
-        {{editor content=data.data.description target="data.description" button=true
-        owner=owner editable=editable}}
+        {{editor richDescription target="system.description"
+        button=true editable=editable}}
       </div>
     </div>
   </section>

--- a/src/templates/items/item-sheet.html
+++ b/src/templates/items/item-sheet.html
@@ -13,31 +13,31 @@
         <div class="form-group">
           <label>{{localize 'ACKS.items.Quantity'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.quantity.value" value="{{data.data.quantity.value}}" data-dtype="Number" />/<input type="text" name="data.quantity.max" value="{{data.data.quantity.max}}" data-dtype="Number" />
+            <input type="text" name="system.quantity.value" value="{{system.quantity.value}}" data-dtype="Number" />/<input type="text" name="system.quantity.max" value="{{system.quantity.max}}" data-dtype="Number" />
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'ACKS.items.Treasure'}}</label>
           <div class="form-fields">
-            <input type="checkbox" name="data.treasure" value="{{data.data.treasure}}" {{checked data.data.treasure}}  data-dtype="Boolean"/>
+            <input type="checkbox" name="system.treasure" value="{{system.treasure}}" {{checked system.treasure}}  data-dtype="Boolean"/>
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'ACKS.items.Cost'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.cost" value="{{data.data.cost}}" data-dtype="Number" />
+            <input type="text" name="system.cost" value="{{system.cost}}" data-dtype="Number" />
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'ACKS.items.Weight'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.weight" value="{{data.data.weight}}" data-dtype="Number" />
+            <input type="text" name="system.weight" value="{{system.weight}}" data-dtype="Number" />
           </div>
         </div>
       </div>
       <div class="description weapon-editor">
-        {{editor content=data.data.description target="data.description" button=true
-        owner=owner editable=editable}}
+        {{editor richDescription target="description"
+        button=true editable=editable}}
       </div>
     </div>
   </section>

--- a/src/templates/items/spell-sheet.html
+++ b/src/templates/items/spell-sheet.html
@@ -13,32 +13,32 @@
         <div class="form-group">
           <label>{{localize 'ACKS.spells.Level'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.lvl" value="{{data.data.lvl}}" data-dtype="Number" />
+            <input type="text" name="system.lvl" value="{{system.lvl}}" data-dtype="Number" />
           </div>
         </div>
         <div class="form-group block-input">
           <label>{{localize 'ACKS.spells.Class'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.class" value="{{data.data.class}}" data-dtype="String" />
+            <input type="text" name="system.class" value="{{system.class}}" data-dtype="String" />
           </div>
         </div>
         <div class="form-group block-input">
           <label>{{localize 'ACKS.spells.Duration'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.duration" value="{{data.data.duration}}" data-dtype="String" />
+            <input type="text" name="system.duration" value="{{system." data-dtype="String" />
           </div>
         </div>
         <div class="form-group block-input">
           <label>{{localize 'ACKS.spells.Range'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.range" value="{{data.data.range}}" data-dtype="String" />
+            <input type="text" name="system.range" value="{{system.}}" data-dtype="String" />
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'ACKS.spells.Save'}}</label>
           <div class="form-fields">
-            <select name="data.save">
-              {{#select data.data.save}}
+            <select name="system.save">
+              {{#select system.}
               <option value=""></option>
               {{#each config.saves_short as |save a|}}
               <option value="{{a}}">{{save}}</option>
@@ -50,13 +50,13 @@
         <div class="form-group block-input">
           <label>{{localize 'ACKS.items.Roll'}}</label>
           <div class="form-fields">
-            <input type="text" name="data.roll" value="{{data.data.roll}}" data-dtype="String" />
+            <input type="text" name="system.roll" value="{{system.}" data-dtype="String" />
           </div>
         </div>
       </div>
       <div class="description">
-        {{editor content=data.data.description target="data.description" button=true
-        owner=owner editable=editable}}
+        {{editor richDescription target="system.description"
+        button=true editable=editable}}
       </div>
     </div>
   </section>

--- a/src/templates/items/weapon-sheet.html
+++ b/src/templates/items/weapon-sheet.html
@@ -23,8 +23,8 @@
             <div class="form-fields">
               <input
                 type="text"
-                name="data.cost"
-                value="{{data.data.cost}}"
+                name="system.cost"
+                value="{{system.
                 data-dtype="Number"
                 />
             </div>
@@ -35,8 +35,8 @@
             <div class="form-fields">
               <input
                 type="text"
-                name="data.weight"
-                value="{{data.data.weight}}"
+                name="system.weight"
+                value="{{system.
                 data-dtype="Number"
                 />
             </div>
@@ -44,7 +44,7 @@
         </div>
       </div>
       <ol class="tag-list">
-        {{#each data.data.tags as |tag|}}
+        {{#each system.tags as |tag|}}
         <li class="tag" title="{{tag.title}}" data-tag="{{tag.value}}">
           <span>{{tag.value}}</span>
           <a class="tag-delete"><i class="fas fa-times"></i></a>
@@ -71,8 +71,8 @@
           <div class="form-fields">
             <input
               type="text"
-              name="data.damage"
-              value="{{data.data.damage}}"
+              name="system.damage"
+              value="{{system.
               data-dtype="String"
               />
           </div>
@@ -83,40 +83,40 @@
           <div class="form-fields">
             <input
               type="text"
-              name="data.bonus"
-              value="{{data.data.bonus}}"
+              name="system.bonus"
+              value="{{system.bonus}}"
               data-dtype="Number"
               />
           </div>
         </div>
         <div class="form-group attack-type">
           <a title="{{localize 'ACKS.items.Melee'}}" class="melee-toggle {{#if
-            data.data.melee}}active{{/if}}"><i class="fas fa-fist-raised"></i></a>
+            system.melee}}active{{/if}}"><i class="fas fa-fist-raised"></i></a>
           <a title="{{localize 'ACKS.items.Missile'}}" class="missile-toggle
-            {{#if data.data.missile}}active{{/if}}"><i class="fas fa-bullseye"></i></a>
+            {{#if system.le}}active{{/if}}"><i class="fas fa-bullseye"></i></a>
         </div>
-        {{#if data.data.missile}}
+        {{#if system.missile}}
         <div class="form-group block-input">
           <label>{{localize 'ACKS.items.Range'}}</label>
           <div class="form-fields range">
             <input
               type="text"
-              name="data.range.short"
-              value="{{data.data.range.short}}"
+              name="system.range.short"
+              value="{{system.range.short}}"
               data-dtype="Number"
               />
               <div class="sep"></div>
               <input
               type="text"
-              name="data.range.medium"
-              value="{{data.data.range.medium}}"
+              name="system.range.medium"
+              value="{{system.range.medium}}"
               data-dtype="Number"
               />
               <div class="sep"></div>
               <input
               type="text"
-              name="data.range.long"
-              value="{{data.data.range.long}}"
+              name="system.range.long"
+              value="{{system.range.long}}"
               data-dtype="Number"
               />
           </div>
@@ -125,8 +125,8 @@
         <div class="form-group">
           <label>{{localize 'ACKS.spells.Save'}}</label>
           <div class="form-fields">
-            <select name="data.save">
-              {{#select data.data.save}}
+            <select name="system.save">
+              {{#select system.}
               <option value=""></option>
               {{#each config.saves_short as |save a|}}
               <option value="{{a}}">{{save}}</option>
@@ -140,18 +140,18 @@
           <div class="form-fields">
             <input
               type="checkbox"
-              name="data.slow"
-              value="{{data.data.slow}}"
+              name="system.slow"
+              value="{{system.slow}}"
               {{checked
-              data.data.slow}}
+              system.slow}}
               data-dtype="Number"
               />
           </div>
         </div>
       </div>
       <div class="description weapon-editor">
-        {{editor content=data.data.description target="data.description" button=true
-        owner=owner editable=editable}}
+        {{editor richDescription target="system.description"
+        button=true editable=editable}}
       </div>
     </div>
   </section>

--- a/src/templates/items/weapon-sheet.html
+++ b/src/templates/items/weapon-sheet.html
@@ -24,7 +24,7 @@
               <input
                 type="text"
                 name="system.cost"
-                value="{{system.
+                value="{{system.cost}}"
                 data-dtype="Number"
                 />
             </div>
@@ -36,7 +36,7 @@
               <input
                 type="text"
                 name="system.weight"
-                value="{{system.
+                value="{{system.weight}}""
                 data-dtype="Number"
                 />
             </div>
@@ -72,7 +72,7 @@
             <input
               type="text"
               name="system.damage"
-              value="{{system.
+              value="{{system.damage}}"
               data-dtype="String"
               />
           </div>
@@ -126,7 +126,7 @@
           <label>{{localize 'ACKS.spells.Save'}}</label>
           <div class="form-fields">
             <select name="system.save">
-              {{#select system.}
+              {{#select system.saves}}
               <option value=""></option>
               {{#each config.saves_short as |save a|}}
               <option value="{{a}}">{{save}}</option>


### PR DESCRIPTION
Hello, I'm contributing a few fixes I was able to ferret out after figuring out how to do debugging in Foundry.
The fixes are as follows:
- Removing all (I hope) of the references to `Document`s' `.data` and `.data.data` members
- Fix the calls to the ``{{editor}}`` Handlebars helper to use the v10+ syntax
- Apparently, `Character`s do not have `details`, but do have a `biography`, so have the notes tab point to that, instead
- Fix the issue with dropping an item into the hotbar be replaced with the macro which opens the item sheet instead of rolling

Please have a look at them and merge them if they seem up to snuff.
Thanks!